### PR TITLE
dunedaq CVMFS repo reorganization

### DIFF
--- a/bin/quick-start.sh
+++ b/bin/quick-start.sh
@@ -5,7 +5,7 @@ edits_check=true
 
 build_script=source_me_to_build
 
-products_dirs="/cvmfs/dune.opensciencegrid.org/dunedaq/products" 
+products_dirs="/cvmfs/dune.opensciencegrid.org/dunedaq/DUNE/products" 
 
 starttime_d=$( date )
 starttime_s=$( date +%s )


### PR DESCRIPTION
change path to cvmfs products area in quick-start.sh after separating UPS products into DUNE and protoDUNE.