### PR TITLE
JCF: Issue #14: update quick-start.sh s.t. we use ers as a ups produc…

### DIFF
--- a/bin/quick-start.sh
+++ b/bin/quick-start.sh
@@ -27,6 +27,7 @@ cmake_version=v3_17_2
 nlohmann_json_version=v3_8_0
 TRACE_version=v3_15_09
 folly_version=v2020_05_25
+ers_version=v0_26_00
 ninja_version=v1_8_2
 
 boost_version_with_dots=$( echo $boost_version | sed -r 's/^v//;s/_/./g' )
@@ -37,7 +38,7 @@ basedir=$PWD
 builddir=$basedir/build
 logdir=$basedir/log
 
-packages="daq-buildtools:develop appfwk:develop ers:dune/ers-00-26-00"
+packages="daq-buildtools:develop appfwk:develop"
 
 export USER=${USER:-$(whoami)}
 export HOSTNAME=${HOSTNAME:-$(hostname)}
@@ -153,6 +154,8 @@ setup_returns=\$setup_returns"\$? "
 setup TRACE $TRACE_version
 setup_returns=\$setup_returns"\$? "
 setup folly $folly_version -q ${gcc_version_qualifier}:prof
+setup_returns=\$setup_returns"\$? "
+setup ers $ers_version -q ${gcc_version_qualifier}:prof
 setup_returns=\$setup_returns"\$? "
 setup ninja $ninja_version 2>/dev/null # Don't care if it fails
 
@@ -410,6 +413,7 @@ find_package(Boost $boost_version_with_dots COMPONENTS unit_test_framework progr
 find_package(TRACE $TRACE_version_with_dots REQUIRED)
 find_package(cetlib REQUIRED)   # Uses the daq-buildtools/cmake/Findcetlib.cmake
 find_package(folly REQUIRED)
+find_package(ers REQUIRED)
 
 find_package(nlohmann_json $nlohmann_json_version_with_dots )
 
@@ -423,8 +427,8 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 add_compile_options( -g -pedantic -Wall -Wextra )
 
-set(DAQ_LIBRARIES_UNIVERSAL ers pthread)
-set(DAQ_INCLUDES_UNIVERSAL \${Boost_INCLUDE_DIRS})
+set(DAQ_LIBRARIES_UNIVERSAL ers::ers pthread)
+set(DAQ_INCLUDES_UNIVERSAL \${Boost_INCLUDE_DIRS} \$ENV{ERS_INC})
 
 set(DAQ_LIBRARIES_UNIVERSAL_EXE \${Boost_PROGRAM_OPTIONS_LIBRARY} \${DAQ_LIBRARIES_UNIVERSAL})
 
@@ -432,9 +436,6 @@ message(WARNING "ctest will *not* work! enable_testing() call had to be disabled
 #enable_testing()
 
 include_directories(SYSTEM \${DAQ_INCLUDES_UNIVERSAL})
-
-include_directories(SYSTEM \${CMAKE_SOURCE_DIR}/ers)
-add_subdirectory(ers)
 
 include_directories(\${CMAKE_SOURCE_DIR}/appfwk/include)
 add_subdirectory(appfwk)

--- a/cmake/DAQ.cmake
+++ b/cmake/DAQ.cmake
@@ -10,7 +10,7 @@ endfunction()
 function(add_unit_test testname)
 
   add_executable( ${testname} unittest/${testname}.cxx )
-  target_link_libraries( ${testname} ${DAQ_LIBRARIES_UNIVERSAL_EXE} ${DAQ_LIBRARIES_PACKAGE}  ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY} )
+  target_link_libraries( ${testname} ${DAQ_LIBRARIES_UNIVERSAL_EXE} ${DAQ_LIBRARIES_PACKAGE}  ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY} ${ARGN} )
   target_include_directories( ${testname} SYSTEM PRIVATE ${DAQ_INCLUDES_UNIVERSAL})
   target_compile_definitions(${testname} PRIVATE "BOOST_TEST_DYN_LINK=1")
   add_test(NAME ${testname} COMMAND ${testname})


### PR DESCRIPTION
…t, not as a downloaded repo

Please note: because this doesn't cause `ers` to be downloaded as a git repo, but rather, sets up `ers` as a ups product, the appfwk `CMakeLists.txt` file needed to be modified as well. Therefore, you'll want to review the corresponding pull request for appfwk at the same time as this pull request. The way to do this is as follows, assuming you're in a clean shell and have cd'd into an empty directory:
```
curl -O https://raw.githubusercontent.com/DUNE-DAQ/daq-buildtools/jcfreeman2/issue14_ers_as_product/bin/quick-start.sh
chmod +x quick-start.sh
sed -r -i 's/edits_check=true/edits_check=false/' quick-start.sh
./quick-start.sh
cd daq-buildtools/
git checkout jcfreeman2/issue14_ers_as_product
cd ../appfwk/
git checkout jcfreeman2/daqbuildtools_issue14_ers_as_product
cd ..
```
And now you can test that things build correctly:
```
. setup_build_environment
./build_daq_software.sh 
```
And that you can also run executables:
```
. setup_runtime_environment
# run your favorite executables
```