### PR TITLE
Jcfreeman2/issue12 daq setup

### DIFF
--- a/cmake/DAQ.cmake
+++ b/cmake/DAQ.cmake
@@ -1,4 +1,27 @@
 
+
+macro(daq_setup_environment)
+
+  set(CMAKE_CXX_STANDARD 17)
+  set(CMAKE_CXX_EXTENSIONS OFF)
+  set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+  set(BUILD_SHARED_LIBS ON)
+
+  # Directories should always be added *before* the current path
+  set(CMAKE_INCLUDE_DIRECTORIES_PROJECT_BEFORE ON)
+  include_directories( ${CMAKE_SOURCE_DIR}/include )
+
+  # Needed for clang-tidy (called by our linters) to work
+  set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
+  add_compile_options( -g -pedantic -Wall -Wextra )
+
+  enable_testing()
+
+endmacro()
+
+
 function( point_build_to output_dir )
 
   set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/${PROJECT_NAME}/${output_dir} PARENT_SCOPE)
@@ -16,3 +39,4 @@ function(add_unit_test testname)
   add_test(NAME ${testname} COMMAND ${testname})
 
 endfunction()
+

--- a/cmake/DAQ.cmake
+++ b/cmake/DAQ.cmake
@@ -33,8 +33,7 @@ endfunction()
 function(add_unit_test testname)
 
   add_executable( ${testname} unittest/${testname}.cxx )
-  target_link_libraries( ${testname} ${DAQ_LIBRARIES_UNIVERSAL_EXE} ${DAQ_LIBRARIES_PACKAGE}  ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY} ${ARGN} )
-  target_include_directories( ${testname} SYSTEM PRIVATE ${DAQ_INCLUDES_UNIVERSAL})
+  target_link_libraries( ${testname} ${ARGN} ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY})
   target_compile_definitions(${testname} PRIVATE "BOOST_TEST_DYN_LINK=1")
   add_test(NAME ${testname} COMMAND ${testname})
 


### PR DESCRIPTION
This pull request corresponds to Issue #12. With this pull request a daq_setup_environment() function has been added to the DAQ module. Every package developer should call this function in their CMakeLists.txt; it does things like

-Enforce standard, extensionless C++17
-Build shared object libraries (as opposed to, e.g., static)
-Allow the linter to be able to interpret what's going on with the code
-Set standard warnings

Note that along with the addition of this function, the superproject/subproject build model has been eliminated. With daq_setup_environment, most of the justification for a superproject CMakeLists.txt file - that all subproject CMakeLists.txt files would have certain things in common - has been shifted into the new function. An example of its use can be found in appfwk's jcfreeman2/daqbuildtools_issue12_daq_setup branch, which has its own pull request. Please observe that for things to not break the code from both pull requests needs to be merged at the same time. 

Since the code is on feature branches, however, you'll need to follow these special instructions in order to test:
```
curl -O https://raw.githubusercontent.com/DUNE-DAQ/daq-buildtools/jcfre
eman2/issue12_daq_setup/bin/quick-start.sh
chmod +x quick-start.sh
sed -r -i 's/edits_check=true/edits_check=false/' quick-start.sh
./quick-start.sh 
cd daq-buildtools
git checkout jcfreeman2/issue12_daq_setup
cd ../appfwk
git checkout jcfreeman2/daqbuildtools_issue12_daq_setup
cd ..
. ./setup_build_environment
./build_daq_software.sh
```
...and from there, you can play around with the appfwk build as usual. 