### PR TITLE
JCF: Issue #13: add daq_install() function to the DAQ module

### DIFF
--- a/bin/quick-start.sh
+++ b/bin/quick-start.sh
@@ -186,10 +186,11 @@ run_tests=false
 clean_build=false 
 pkgname_specified=false
 pkgname="appfwk"
+perform_install=false
 
 for arg in "\$@" ; do
   if [[ "\$arg" == "--help" ]]; then
-    echo "Usage: "\$( basename \$0 )" --clean --unittest --pkgname <name> --help "
+    echo "Usage: "\$( basename \$0 )" --clean --unittest --install --pkgname <name> --help "
     echo
     echo " --clean means the contents of ./build/<pkgname> are deleted and CMake's config+generate+build stages are run"
     echo " --unittest means that unit test executables found in build are all run"
@@ -209,6 +210,8 @@ for arg in "\$@" ; do
   elif \$pkgname_specified ; then
     pkgname="\$arg"
     pkgname_specified=false
+  elif [[ "\$arg" == "--install" ]]; then
+    perform_install=true
   else
     echo "Unknown argument provided; run with \" --help\" to see valid options. Exiting..." >&2
     exit 1
@@ -368,6 +371,25 @@ else
   echo "CMake's build stage completed successfully"
 fi
 
+if \$perform_install ; then
+  cd \$builddir
+  cmake --build . --target install -- -j \$nprocs
+ 
+  if [[ "\$?" == "0" ]]; then
+    echo 
+    echo "Installation complete."
+    echo "This implies your code successfully compiled before installation; you can either scroll up or run \"less \$build_log\" to see build results"
+  else
+    echo
+    echo "Installation failed. There was a problem running \"cmake --build . --target install -- -j \$nprocs\"" >&2
+    echo "Exiting..." >&2
+    exit 50
+  fi
+ 
+fi
+
+
+
 if \$run_tests ; then
  
      echo 
@@ -392,7 +414,7 @@ if \$run_tests ; then
      echo 
      echo 
      echo "Testing complete."
-     echo "This implies your code compiled before testing, though you can either scroll up or run \"less \$build_log\" to see build results"
+     echo "This implies your code successfully compiled before testing; you can either scroll up or run \"less \$build_log\" to see build results"
      echo "Test results are saved and can be viewed via \"less \$test_log\""
      echo
 fi

--- a/configs/Config.cmake.in
+++ b/configs/Config.cmake.in
@@ -1,0 +1,13 @@
+
+@PACKAGE_INIT@
+
+include(CMakeFindDependencyMacro)
+
+# Insert find_dependency() calls for your package's dependencies in
+# the place of this comment. Make sure they match up with the
+# find_package calls in your package's CMakeLists.txt file
+
+set_and_check(targets_file ${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake)
+include(${targets_file})
+
+check_required_components(@PROJECT_NAME@)


### PR DESCRIPTION
A daq_install function, taking a version and a list of targets,
has been added to the DAQ module. The intent is that if a user
wants to install their package in the local development area
(specifically, in the new ./install subdirectory) they can call
this function at the bottom of their CMakeLists.txt file.

In addition to calling this function, they'll also need a file
called <pkgname>Config.cmake.in in the root of their code directory.
They can make one by copying over daq-buildtools' configs/Config.cmake.in
added in this commit, and replacing the comment in the file with the needed
find_dependency() calls.

Once this is done, they can then build and locally install their package
via "build_daq_software.sh --install --pkgname <their package name>"