### PR TITLE
Make daq-buildtools work in a packaging system, such as spack

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,5 @@
-project(daq-buildtools 1.1.1)
+cmake_minimum_required(VERSION 3.12)
+project(daq-buildtools VERSION 1.1.1)
 
 # Installation stuff copied from the double-conversion CMakeLists.txt, which in turn got it from
 # https://github.com/forexample/package-example

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,9 +44,9 @@ install(
     DESTINATION "${config_install_dir}"
 )
 
-install(
-    EXPORT "${targets_export_name}"
-    NAMESPACE "${namespace}"
-    DESTINATION "${config_install_dir}"
-)
+# install(
+#     EXPORT "${targets_export_name}"
+#     NAMESPACE "${namespace}"
+#     DESTINATION "${config_install_dir}"
+# )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,51 @@
+project(daq-buildtools 1.1.1)
+
+# Installation stuff copied from the double-conversion CMakeLists.txt, which in turn got it from
+# https://github.com/forexample/package-example
+
+include(GNUInstallDirs)
+
+# Layout. This works for all platforms:
+#   * <prefix>/lib/cmake/<PROJECT-NAME>
+#   * <prefix>/lib/
+#   * <prefix>/include/
+set(config_install_dir "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}")
+
+set(generated_dir "${CMAKE_CURRENT_BINARY_DIR}/generated")
+
+# Configuration
+set(version_config "${generated_dir}/${PROJECT_NAME}ConfigVersion.cmake")
+set(project_config "${generated_dir}/${PROJECT_NAME}Config.cmake")
+set(targets_export_name "${PROJECT_NAME}Targets")
+set(namespace "${PROJECT_NAME}::")
+
+# Include module with function 'write_basic_package_version_file'
+include(CMakePackageConfigHelpers)
+
+# Configure '<PROJECT-NAME>ConfigVersion.cmake'
+# Note: PROJECT_VERSION is used as a VERSION
+write_basic_package_version_file(
+    "${version_config}" COMPATIBILITY SameMajorVersion
+)
+
+# Configure '<PROJECT-NAME>Config.cmake'
+# Use variables:
+#   * targets_export_name
+#   * PROJECT_NAME
+configure_package_config_file(
+    "cmake/Config.cmake.in"
+    "${project_config}"
+    INSTALL_DESTINATION "${config_install_dir}"
+)
+
+install(
+    FILES "${project_config}" "${version_config}" "cmake/DAQ.cmake" "cmake/Findcetlib.cmake"
+    DESTINATION "${config_install_dir}"
+)
+
+install(
+    EXPORT "${targets_export_name}"
+    NAMESPACE "${namespace}"
+    DESTINATION "${config_install_dir}"
+)
+

--- a/bin/quick-start.sh
+++ b/bin/quick-start.sh
@@ -122,7 +122,7 @@ if [[ -z \$DUNE_SETUP_BUILD_ENVIRONMENT_SCRIPT_SOURCED ]]; then
 
 echo "This script hasn't yet been sourced (successfully) in this shell; setting up the build environment"
 
-export DUNE_INSTALL_DIR=\$(dirname \$(readlink -f \${BASH_SOURCE[0]}) )/install
+export DUNE_INSTALL_DIR=\$(cd \$(dirname \${BASH_SOURCE}) && pwd)/install
 export CMAKE_PREFIX_PATH=\$CMAKE_PREFIX_PATH:\$DUNE_INSTALL_DIR/lib64:\$DUNE_INSTALL_DIR/lib
 
 EOF

--- a/bin/quick-start.sh
+++ b/bin/quick-start.sh
@@ -236,22 +236,12 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-
 find_package(TRACE REQUIRED)
-
-# May eventually want to uncomment the Boost find_package, but for the
-# time being it's handled in the package's CMakeLists.txt files
-
-#find_package(Boost REQUIRED COMPONENTS unit_test_framework program_options)
-
-if (CMAKE_COMPILER_VERSION VERSION_LESS 9.3.0)
-   add_compile_options( -Wno-virtual-move-assign ) # False positive: v8.2.0 complains even if there's no data in base class
-endif()
 
 add_subdirectory(ers)
 add_subdirectory(app-framework)
 
-set(CMAKE_EXPORT_COMPILE_COMMANDS ON CACHE BOOL "Set to ON to produce a compile_commands.json file which clang-tidy can use" FORCE)
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 EOF
 

--- a/cmake/Config.cmake.in
+++ b/cmake/Config.cmake.in
@@ -12,6 +12,6 @@ include(CMakeFindDependencyMacro)
 # set_and_check(targets_file ${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake)
 # include(${targets_file})
 
-list(APPEND CMAKE_MODULE_PATH ${PACKAGE_PREFIX_DIR}/lib64/cmake)
+list(APPEND CMAKE_MODULE_PATH ${PACKAGE_PREFIX_DIR}/lib64/cmake/daq-buildtools)
 
 check_required_components(@PROJECT_NAME@)

--- a/cmake/Config.cmake.in
+++ b/cmake/Config.cmake.in
@@ -10,4 +10,6 @@ include(CMakeFindDependencyMacro)
 set_and_check(targets_file ${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake)
 include(${targets_file})
 
+list(APPEND CMAKE_MODULE_PATH ${PACKAGE_PREFIX_DIR}/lib64/cmake)
+
 check_required_components(@PROJECT_NAME@)

--- a/cmake/Config.cmake.in
+++ b/cmake/Config.cmake.in
@@ -13,5 +13,6 @@ include(CMakeFindDependencyMacro)
 # include(${targets_file})
 
 list(APPEND CMAKE_MODULE_PATH ${PACKAGE_PREFIX_DIR}/lib64/cmake/daq-buildtools)
+include(${PACKAGE_PREFIX_DIR}/lib64/cmake/daq-buildtools/DAQ.cmake)
 
 check_required_components(@PROJECT_NAME@)

--- a/cmake/Config.cmake.in
+++ b/cmake/Config.cmake.in
@@ -1,0 +1,13 @@
+
+@PACKAGE_INIT@
+
+include(CMakeFindDependencyMacro)
+
+# Insert find_dependency() calls for your package's dependencies in
+# the place of this comment. Make sure they match up with the
+# find_package calls in your package's CMakeLists.txt file
+
+set_and_check(targets_file ${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake)
+include(${targets_file})
+
+check_required_components(@PROJECT_NAME@)

--- a/cmake/Config.cmake.in
+++ b/cmake/Config.cmake.in
@@ -7,8 +7,10 @@ include(CMakeFindDependencyMacro)
 # the place of this comment. Make sure they match up with the
 # find_package calls in your package's CMakeLists.txt file
 
-set_and_check(targets_file ${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake)
-include(${targets_file})
+# PAR 2020-08-20: No targets yet. There might be some later, so leave this here and commented out
+
+# set_and_check(targets_file ${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake)
+# include(${targets_file})
 
 list(APPEND CMAKE_MODULE_PATH ${PACKAGE_PREFIX_DIR}/lib64/cmake)
 

--- a/cmake/DAQ.cmake
+++ b/cmake/DAQ.cmake
@@ -91,8 +91,6 @@ function(daq_install)
 
   cmake_parse_arguments(DAQ_INSTALL "" "" TARGETS ${ARGN} )
 
-  set(CMAKE_INSTALL_PREFIX ${CMAKE_CURRENT_SOURCE_DIR}/../install/${PROJECT_NAME} CACHE PATH "No comment" FORCE)
-
   set(exportset ${PROJECT_NAME}Targets)
   set(cmakedestination ${CMAKE_INSTALL_LIBDIR}/${PROJECT_NAME}/cmake)
 

--- a/cmake/DAQ.cmake
+++ b/cmake/DAQ.cmake
@@ -92,7 +92,7 @@ function(daq_install)
   cmake_parse_arguments(DAQ_INSTALL "" "" TARGETS ${ARGN} )
 
   set(exportset ${PROJECT_NAME}Targets)
-  set(cmakedestination ${CMAKE_INSTALL_LIBDIR}/${PROJECT_NAME}/cmake)
+  set(cmakedestination ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME})
 
   install(TARGETS ${DAQ_INSTALL_TARGETS} EXPORT ${exportset} )
   install(EXPORT ${exportset} FILE ${exportset}.cmake NAMESPACE ${PROJECT_NAME}:: DESTINATION ${cmakedestination} )

--- a/cmake/Findcetlib.cmake
+++ b/cmake/Findcetlib.cmake
@@ -7,7 +7,7 @@ if(EXISTS $ENV{CETLIB_LIB})
   set(cetlib_FOUND TRUE)
 else()
 	# Spack
-	find_package(cetlib REQUIRED)
+	find_package(cetlib REQUIRED CONFIG)
 	set(CETLIB cetlib)
 	set(CETLIB_EXCEPT cetlib_except)
 endif()

--- a/scripts/setup_runtime_environment
+++ b/scripts/setup_runtime_environment
@@ -27,6 +27,60 @@ else
       echo "script won't try to source it"
 fi
 
-export PATH=$PATH:$DUNE_INSTALL_DIR/bin
-export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$DUNE_INSTALL_DIR/lib64
-export CET_PLUGIN_PATH=$CET_PLUGIN_PATH:$DUNE_INSTALL_DIR/lib64
+# Colors
+COL_RED="\e[31m"
+COL_GREEN="\e[32m"
+COL_YELLOW="\e[33m"
+COL_BLUE="\e[34m"
+COL_NULL="\e[0m"
+
+#------------------------------------------------------------------------------
+function add_path() {
+  # Assert that we got enough arguments
+  if [[ $# -ne 2 ]]; then
+    echo "path add: needs 2 arguments"
+    return 1
+  fi
+  PATH_NAME=$1
+  PATH_VAL=${!1}
+  PATH_ADD=$2
+
+  # Add the new path only if it is not already there
+  if [[ ":$PATH_VAL:" != *":$PATH_ADD:"* ]]; then
+    # Note
+    # ${PARAMETER:+WORD}
+    #   This form expands to nothing if the parameter is unset or empty. If it
+    #   is set, it does not expand to the parameter's value, but to some text
+    #   you can specify
+    PATH_VAL="$PATH_ADD${PATH_VAL:+":$PATH_VAL"}"
+
+    echo -e "${COL_BLUE}Added ${PATH_ADD} to ${PATH_NAME}${COL_NULL}"
+
+    # use eval to reset the target
+    eval "${PATH_NAME}=${PATH_VAL}"
+  fi
+}
+#------------------------------------------------------------------------------
+
+
+#------------------------------------------------------------------------------
+function add_many_paths() {
+  for d in "${@:2}"
+  do
+    add_path $1 $d
+  done
+}
+#------------------------------------------------------------------------------
+
+DAQ_APPS_PATHS=$(find $BUILD_DIR -type d -not -path '*CMakeFiles*' -name 'apps')
+DAQ_LIB_PATHS=$(find $BUILD_DIR -type d -not -path '*CMakeFiles*' -name 'src')
+DAQ_TEST_PATHS=$(find $BUILD_DIR -type d -not -path '*CMakeFiles*' -name 'test')
+
+add_many_paths PATH $DAQ_APPS_PATHS $DAQ_TEST_PATHS
+add_many_paths LD_LIBRARY_PATH $DAQ_LIB_PATHS $DAQ_TEST_PATHS
+add_many_paths CET_PLUGIN_PATH $DAQ_LIB_PATHS $DAQ_TEST_PATHS
+
+unset DAQ_APPS_PATHS DAQ_LIB_PATHS DAQ_TEST_PATHS
+
+echo -e "${COL_GREEN}This script has been sourced successfully${COL_NULL}"
+echo

--- a/scripts/setup_runtime_environment
+++ b/scripts/setup_runtime_environment
@@ -27,60 +27,6 @@ else
       echo "script won't try to source it"
 fi
 
-# Colors
-COL_RED="\e[31m"
-COL_GREEN="\e[32m"
-COL_YELLOW="\e[33m"
-COL_BLUE="\e[34m"
-COL_NULL="\e[0m"
-
-#------------------------------------------------------------------------------
-function add_path() {
-  # Assert that we got enough arguments
-  if [[ $# -ne 2 ]]; then
-    echo "path add: needs 2 arguments"
-    return 1
-  fi
-  PATH_NAME=$1
-  PATH_VAL=${!1}
-  PATH_ADD=$2
-
-  # Add the new path only if it is not already there
-  if [[ ":$PATH_VAL:" != *":$PATH_ADD:"* ]]; then
-    # Note
-    # ${PARAMETER:+WORD}
-    #   This form expands to nothing if the parameter is unset or empty. If it
-    #   is set, it does not expand to the parameter's value, but to some text
-    #   you can specify
-    PATH_VAL="$PATH_ADD${PATH_VAL:+":$PATH_VAL"}"
-
-    echo -e "${COL_BLUE}Added ${PATH_ADD} to ${PATH_NAME}${COL_NULL}"
-
-    # use eval to reset the target
-    eval "${PATH_NAME}=${PATH_VAL}"
-  fi
-}
-#------------------------------------------------------------------------------
-
-
-#------------------------------------------------------------------------------
-function add_many_paths() {
-  for d in "${@:2}"
-  do
-    add_path $1 $d
-  done
-}
-#------------------------------------------------------------------------------
-
-DAQ_APPS_PATHS=$(find $BUILD_DIR -type d -not -path '*CMakeFiles*' -name 'apps')
-DAQ_LIB_PATHS=$(find $BUILD_DIR -type d -not -path '*CMakeFiles*' -name 'src')
-DAQ_TEST_PATHS=$(find $BUILD_DIR -type d -not -path '*CMakeFiles*' -name 'test')
-
-add_many_paths PATH $DAQ_APPS_PATHS $DAQ_TEST_PATHS
-add_many_paths LD_LIBRARY_PATH $DAQ_LIB_PATHS $DAQ_TEST_PATHS
-add_many_paths CET_PLUGIN_PATH $DAQ_LIB_PATHS $DAQ_TEST_PATHS
-
-unset DAQ_APPS_PATHS DAQ_LIB_PATHS DAQ_TEST_PATHS
-
-echo -e "${COL_GREEN}This script has been sourced successfully${COL_NULL}"
-echo
+export PATH=$PATH:$DUNE_INSTALL_DIR/bin
+export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$DUNE_INSTALL_DIR/lib64
+export CET_PLUGIN_PATH=$CET_PLUGIN_PATH:$DUNE_INSTALL_DIR/lib64


### PR DESCRIPTION
This PR makes daq-buildtools behave like a regular cmake package so that it can be installed with a package manager such as spack, and so that packages that depend on it can also be installed this way. There are changes to the package itself, to the cmake scripts that are provided to downstream packages, and to `quick-start.sh` and friends. I'm less confident about the last of these, because `quick-start.sh` is quite convoluted and has a lot of hardcoded paths and URLs.

### Changes to the package itself

This PR adds an install step to the daq-buildtools build. Currently only `DAQ.cmake`, `Findcetlib.cmake` and a `daq-buildtoolsConfig.cmake` file are installed. Maybe there are other files that should be installed?

### Changes to the cmake scripts for downstream packages

There is no more hardcoding of paths in cmake scripts. Downstream packages should `find_package(daq-buildtools REQUIRED)`, which will make all of the functions in `DAQ.cmake` available. The `daq_install()` function obeys `$CMAKE_INSTALL_PREFIX` set by the user.

### Changes to `quick-start.sh` and friends

`setup_build_environment` sets `$DUNE_INSTALL_DIR` to point to the `install/` subdirectory of its location, and `build_daq_software` sets `CMAKE_INSTALL_PREFIX` to `$DUNE_INSTALL_DIR`. It's now necessary to `build_daq_software --install --pkgname daq-buildtools` before building the app framework