### PR TITLE
build_daq_software auto-detects new packages in `sourcecode/`

### DIFF
--- a/bin/quick-start.sh
+++ b/bin/quick-start.sh
@@ -278,7 +278,7 @@ fi
 
 starttime_cfggen_d=\$( date )
 starttime_cfggen_s=\$( date +%s )
-cmake \${generator_arg} $srcdir |& tee \$build_log
+unbuffer cmake \${generator_arg} $srcdir |& tee \$build_log
 retval=\${PIPESTATUS[0]}  # Captures the return value of cmake, not tee
 endtime_cfggen_d=\$( date )
 endtime_cfggen_s=\$( date +%s )
@@ -333,7 +333,7 @@ if \$verbose; then
   build_options=" --verbose"
 fi
 
-cmake --build . \$build_options -- \$nprocs_argument |& tee -a \$build_log
+unbuffer cmake --build . \$build_options -- \$nprocs_argument |& tee -a \$build_log
 
 retval=\${PIPESTATUS[0]}  # Captures the return value of cmake --build, not tee
 endtime_build_d=\$( date )
@@ -384,7 +384,7 @@ fi
 
 if \$perform_install ; then
   cd $builddir
-  cmake --build . --target install -- -j \$nprocs
+  unbuffer cmake --build . --target install -- -j \$nprocs
  
   if [[ "\$?" == "0" ]]; then
     echo 

--- a/cmake/DAQ.cmake
+++ b/cmake/DAQ.cmake
@@ -35,7 +35,7 @@ macro(daq_setup_environment)
   set(CMAKE_INSTALL_BINDIR ${PROJECT_NAME}/${CMAKE_INSTALL_BINDIR})
   set(CMAKE_INSTALL_INCLUDEDIR ${PROJECT_NAME}/${CMAKE_INSTALL_INCLUDEDIR})
 
-  add_compile_options( -g -pedantic -Wall -Wextra )
+  add_compile_options( -g -pedantic -Wall -Wextra -fdiagnostics-color=always )
 
   enable_testing()
 

--- a/configs/CMakeLists.txt
+++ b/configs/CMakeLists.txt
@@ -6,7 +6,7 @@ project(dunedaq)
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/../daq-buildtools/cmake ${CMAKE_MODULE_PATH})
 
 macro(subdirlist result curdir)
-  file(GLOB children RELATIVE ${curdir} ${curdir}/*)
+  file(GLOB children RELATIVE ${curdir} CONFIGURE_DEPENDS ${curdir}/*)
   set(dirlist "")
   foreach (child ${children})
     if (IS_DIRECTORY ${curdir}/${child})


### PR DESCRIPTION
This PR modifies the top-level CMakeLists.txt to force a check on packages in `sourcecode/` every time cmake is run.

It also add color support for C++ errors in ninjia (and cmake).