### PR TITLE
Jcfreeman2/issue44 better daq install error message

### DIFF
--- a/cmake/DAQ.cmake
+++ b/cmake/DAQ.cmake
@@ -32,9 +32,7 @@ macro(daq_setup_environment)
 
   set(CMAKE_INSTALL_CMAKEDIR   ${CMAKE_INSTALL_LIBDIR}/${PROJECT_NAME}/cmake ) # Not defined in GNUInstallDirs
 
-  # JCF, Oct-7-2020, TODO when it becomes standard for us to use a CMake version 3.7 or newer:
-  # Replace this ad-hoc DAQ_PROJECT_HAS_TARGETS logic by checking the BUILDSYSTM_TARGETS variable instead
-  set(DAQ_PROJECT_HAS_TARGETS false)
+  set(DAQ_PROJECT_INSTALLS_TARGETS false)
 
   add_compile_options( -g -pedantic -Wall -Wextra -fdiagnostics-color=always )
 
@@ -116,7 +114,7 @@ function(daq_add_library)
 
   _daq_define_exportname()
   install(TARGETS ${libname} EXPORT ${DAQ_PROJECT_EXPORTNAME} )
-  set(DAQ_PROJECT_HAS_TARGETS true PARENT_SCOPE)
+  set(DAQ_PROJECT_INSTALLS_TARGETS true PARENT_SCOPE)
 
 endfunction()
 
@@ -158,7 +156,7 @@ function(daq_add_plugin pluginname plugintype)
   else()
     _daq_define_exportname()
     install(TARGETS ${pluginlibname} EXPORT ${DAQ_PROJECT_EXPORTNAME} DESTINATION ${CMAKE_INSTALL_LIBDIR})
-    set(DAQ_PROJECT_HAS_TARGETS true PARENT_SCOPE)
+    set(DAQ_PROJECT_INSTALLS_TARGETS true PARENT_SCOPE)
   endif()
 
   endfunction()
@@ -218,7 +216,7 @@ function(daq_add_application appname)
   else()
     _daq_define_exportname()
     install(TARGETS ${appname} EXPORT ${DAQ_PROJECT_EXPORTNAME} )
-    set(DAQ_PROJECT_HAS_TARGETS true PARENT_SCOPE)
+    set(DAQ_PROJECT_INSTALLS_TARGETS true PARENT_SCOPE)
   endif()
 
 endfunction()
@@ -264,7 +262,7 @@ endfunction()
 
 function(daq_install) 
 
-  if (${DAQ_PROJECT_HAS_TARGETS})
+  if (${DAQ_PROJECT_INSTALLS_TARGETS})
     _daq_define_exportname()
     install(EXPORT ${DAQ_PROJECT_EXPORTNAME} FILE ${DAQ_PROJECT_EXPORTNAME}.cmake NAMESPACE ${PROJECT_NAME}:: DESTINATION ${CMAKE_INSTALL_CMAKEDIR} )
   endif()

--- a/cmake/DAQ.cmake
+++ b/cmake/DAQ.cmake
@@ -32,6 +32,10 @@ macro(daq_setup_environment)
 
   set(CMAKE_INSTALL_CMAKEDIR   ${CMAKE_INSTALL_LIBDIR}/${PROJECT_NAME}/cmake ) # Not defined in GNUInstallDirs
 
+  # JCF, Oct-7-2020, TODO when it becomes standard for us to use a CMake version 3.7 or newer:
+  # Replace this ad-hoc DAQ_PROJECT_HAS_TARGETS logic by checking the BUILDSYSTM_TARGETS variable instead
+  set(DAQ_PROJECT_HAS_TARGETS false)
+
   add_compile_options( -g -pedantic -Wall -Wextra -fdiagnostics-color=always )
 
   enable_testing()
@@ -112,6 +116,7 @@ function(daq_add_library)
 
   _daq_define_exportname()
   install(TARGETS ${libname} EXPORT ${DAQ_PROJECT_EXPORTNAME} )
+  set(DAQ_PROJECT_HAS_TARGETS true PARENT_SCOPE)
 
 endfunction()
 
@@ -153,6 +158,7 @@ function(daq_add_plugin pluginname plugintype)
   else()
     _daq_define_exportname()
     install(TARGETS ${pluginlibname} EXPORT ${DAQ_PROJECT_EXPORTNAME} DESTINATION ${CMAKE_INSTALL_LIBDIR})
+    set(DAQ_PROJECT_HAS_TARGETS true PARENT_SCOPE)
   endif()
 
   endfunction()
@@ -212,6 +218,7 @@ function(daq_add_application appname)
   else()
     _daq_define_exportname()
     install(TARGETS ${appname} EXPORT ${DAQ_PROJECT_EXPORTNAME} )
+    set(DAQ_PROJECT_HAS_TARGETS true PARENT_SCOPE)
   endif()
 
 endfunction()
@@ -257,9 +264,7 @@ endfunction()
 
 function(daq_install) 
 
-  get_property(listoftargets DIRECTORY PROPERTY BUILDSYSTEM_TARGETS)	 	     
-
-  if (listoftargets)
+  if (${DAQ_PROJECT_HAS_TARGETS})
     _daq_define_exportname()
     install(EXPORT ${DAQ_PROJECT_EXPORTNAME} FILE ${DAQ_PROJECT_EXPORTNAME}.cmake NAMESPACE ${PROJECT_NAME}:: DESTINATION ${CMAKE_INSTALL_CMAKEDIR} )
   endif()


### PR DESCRIPTION
Previously, if you didn't have any built targets in your project which you wanted installed, if you called `daq_install` in your CMakeLists.txt you'd not only get a fatal error, but a fatal error accompanied by a not-immediately-illuminating error:
```
-- Configuring done
CMake Error: INSTALL(EXPORT) given unknown export "<your packagename>Targets"
-- Generating done
```
With this pull request, you don't get this confusing fatal error. While in the Issue #44 writeup I suggested we make calling `daq_install` when there aren't any built targets an error, this shouldn't be the case since `daq_install` can also do things like copy headers and CMake modules to the installation area (the latter being the case with the daq-builtools package itself)
