### PR TITLE
JCF: Issue #52: move unbuffer check out of if-block so build_daq_soft…

### DIFF
--- a/bin/quick-start.sh
+++ b/bin/quick-start.sh
@@ -273,6 +273,11 @@ fi
 
 build_log=$logdir/build_attempt_\$( date | sed -r 's/[: ]+/_/g' ).log
 
+can_unbuffer=false
+if [[ -n \$( which unbuffer ) ]]; then
+  can_unbuffer=true
+fi
+
 # We usually only need to explicitly run the CMake configure+generate
 # makefiles stages when it hasn't already been successfully run;
 # otherwise we can skip to the compilation. We use the existence of
@@ -284,11 +289,6 @@ if ! [ -e CMakeCache.txt ];then
 generator_arg=
 if [ "x\${SETUP_NINJA}" != "x" ]; then
   generator_arg="-G Ninja"
-fi
-
-can_unbuffer=false
-if [[ -n \$( which unbuffer ) ]]; then
-  can_unbuffer=true
 fi
 
 starttime_cfggen_d=\$( date )


### PR DESCRIPTION
…ware.sh doesn't try using an undefined variable on systems which don't have the unbuffer command

To test this, you'll want to do the following to get and use quick-start.sh:
```
curl -O https://raw.githubusercontent.com/DUNE-DAQ/daq-buildtools/jcfreeman2/issue52_initialize_can_unbuffer/bin/quick-start.sh
sed -i -r 's/edits_check=true/edits_check=false/g' quick-start.sh
```