### PR TITLE
Jcfreeman2/issue45 headeronly library

### DIFF
--- a/cmake/DAQ.cmake
+++ b/cmake/DAQ.cmake
@@ -55,6 +55,7 @@ macro( _daq_set_target_output_dirs target output_dir )
 
 endmacro()
 
+
 ####################################################################################################
 macro( _daq_define_exportname )
   set( DAQ_PROJECT_EXPORTNAME ${PROJECT_NAME}Targets )
@@ -106,11 +107,16 @@ function(daq_add_library)
     endif()
   endforeach()
 
-  add_library(${libname} SHARED ${libsrcs})
-  target_link_libraries(${libname} PUBLIC ${LIBOPTS_LINK_LIBRARIES}) 
-  target_include_directories(${libname} PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include> $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}> )
-
-  _daq_set_target_output_dirs( ${libname} ${LIB_PATH} )
+  if (libsrcs)
+    add_library(${libname} SHARED ${libsrcs})
+    target_link_libraries(${libname} PUBLIC ${LIBOPTS_LINK_LIBRARIES}) 
+    target_include_directories(${libname} PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include> $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}> )
+    _daq_set_target_output_dirs( ${libname} ${LIB_PATH} )
+  else()
+    add_library(${libname} INTERFACE)
+    target_link_libraries(${libname} INTERFACE ${LIBOPTS_LINK_LIBRARIES})
+    target_include_directories(${libname} INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include> $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}> )
+  endif()
 
   _daq_define_exportname()
   install(TARGETS ${libname} EXPORT ${DAQ_PROJECT_EXPORTNAME} )

--- a/configs/CMakeLists.txt
+++ b/configs/CMakeLists.txt
@@ -22,7 +22,7 @@ include(DAQTopprojHelpers)
 # development area, the developer is encouraged to add it to its
 # appropriate place in this list
 
-set(build_order "daq-buildtools" "cmdlib" "restcmd" "appfwk" "ipm" "driver" "udaq-readout" "ddpdemo" "listrev")
+set(build_order "daq-buildtools" "logging" "cmdlib" "restcmd" "appfwk" "ipm" "driver" "udaq-readout" "ddpdemo" "listrev")
 
 daq_add_subpackages("${build_order}") 
 


### PR DESCRIPTION
With this PR, functionality's been added to `daq_add_library` s.t. if you don't supply it with any *.cpp (source) files, it will no longer register an error. Instead, rather than building a shared object library with the target `packagename::packagename` associated with it as would be the case if it was given source files, it will instead associate the target with the public headers. This, e.g., allows for a much simpler build of the header-only logging library, https://github.com/DUNE-DAQ/logging (see its new jcfreeman2/build_against_daq-buildtools_issue45 branch).