### PR TITLE
Add zmq to ups products (used by IPM)

### DIFF
--- a/configs/dunedaq_area.sh
+++ b/configs/dunedaq_area.sh
@@ -14,7 +14,7 @@ dune_products=(
     "nlohmann_json v3_9_0b e19:prof"
     "ninja v1_10_0"
     "pistache v2020_10_07 e19:prof"
-    "zmq v4_3_1 e19:prof"
+    "zmq v4_3_1b e19:prof"
 )
 
 dune_python="v3_8_3b"

--- a/configs/dunedaq_area.sh
+++ b/configs/dunedaq_area.sh
@@ -14,6 +14,7 @@ dune_products=(
     "nlohmann_json v3_9_0b e19:prof"
     "ninja v1_10_0"
     "pistache v2020_10_07 e19:prof"
+    "zmq v4_3_1 e19:prof"
 )
 
 dune_python="v3_8_3b"


### PR DESCRIPTION
The upcoming IPM library uses the zmq product from the dunedaq cvmfs area, so this PR adds zmq to the list of ups products set up in a new working area.