### PR TITLE
Issue 80: Workaround to find bailing out when relative paths are included in PATH

### DIFF
--- a/bin/dbt-create.sh
+++ b/bin/dbt-create.sh
@@ -68,11 +68,7 @@ done
 ARGS=("$@")
 
 if [[ "${SHOW_RELEASE_LIST}" == true ]]; then
-    # How? RELEASE_BASEPATH subdirs matching some condition? i.e. dunedaq_area.sh file in it?
-    FOUND_RELEASES=($(find ${RELEASE_BASEPATH} -maxdepth 2 -name ${UPS_PKGLIST} -execdir pwd \;))
-    for rel in "${FOUND_RELEASES[@]}"; do
-        echo " - $(basename ${rel})"
-    done
+    list_releases
     exit 0;
 fi
 

--- a/scripts/dbt-setup-tools.sh
+++ b/scripts/dbt-setup-tools.sh
@@ -78,6 +78,17 @@ function find_work_area() {
 
 
 #------------------------------------------------------------------------------
+function list_releases() {
+    # How? RELEASE_BASEPATH subdirs matching some condition? i.e. dunedaq_area.sh file in it?
+    FOUND_RELEASES=($(PATH=/usr/bin find ${RELEASE_BASEPATH} -maxdepth 2 -name ${UPS_PKGLIST} -execdir pwd \;))
+    for rel in "${FOUND_RELEASES[@]}"; do
+        echo " - $(basename ${rel})"
+    done 
+}
+#------------------------------------------------------------------------------
+
+
+#------------------------------------------------------------------------------
 function add_path() {
   # Assert that we got enough arguments
   if [[ $# -ne 2 ]]; then


### PR DESCRIPTION
This PR solves #80 by locally setting `PATH=/usr/bin` before running `find` to discover available releases.
Also, the release-listing code is now wrapped in a  `dbt-setup-tools` function.