### PR TITLE
Revert "guards for obvious mistakes from users and devs"

### DIFF
--- a/bin/dbt-build.sh
+++ b/bin/dbt-build.sh
@@ -1,6 +1,4 @@
-#!/usr/bin/env bash
-set -o errexit -o nounset -o pipefail
-IFS=$'\n\t\v'
+#!/bin/bash
 
 HERE=$(cd $(dirname $(readlink -f ${BASH_SOURCE})) && pwd)
 
@@ -8,7 +6,7 @@ HERE=$(cd $(dirname $(readlink -f ${BASH_SOURCE})) && pwd)
 source ${DBT_ROOT}/scripts/dbt-setup-tools.sh
 
 BASEDIR=$(find_work_area)
-test -n ${BASEDIR:-} || error "DBT Work area directory not found. Exiting..." 
+test -n $BASEDIR || error "DBT Work area directory not found. Exiting..." 
 
 BUILDDIR=${BASEDIR}/build
 LOGDIR=${BASEDIR}/log
@@ -59,13 +57,13 @@ while ((i_arg < $#)); do
     debug_build=true
   elif [[ "$arg" == "--unittest" ]]; then
     run_tests=true
-    if [[ -n ${nextarg:-} && "$nextarg" =~ ^[^\-] ]]; then
+    if [[ -n $nextarg && "$nextarg" =~ ^[^\-] ]]; then
 	package_to_test=$nextarg
 	i_arg=$((i_arg + 1))
     fi
   elif [[ "$arg" == "--lint" ]]; then
     lint=true
-    if [[ -n ${nextarg:-} && "$nextarg" =~ ^[^\-] ]]; then
+    if [[ -n $nextarg && "$nextarg" =~ ^[^\-] ]]; then
 	package_to_lint=$nextarg
 	i_arg=$((i_arg + 1))
     fi
@@ -83,7 +81,7 @@ while ((i_arg < $#)); do
 
 done
 
-if [[ -z ${DBT_SETUP_BUILD_ENVIRONMENT_SCRIPT_SOURCED:-} ]]; then
+if [[ -z $DBT_SETUP_BUILD_ENVIRONMENT_SCRIPT_SOURCED ]]; then
  
 error "$( cat<<EOF
 
@@ -94,14 +92,14 @@ EOF
 )"
 fi
 
-if ${debug_build:-} ; then
+if $debug_build ; then
     export DBT_DEBUG=true
 fi
 
-test -d ${BUILDDIR:-} || error "Expected build directory \"$BUILDDIR\" not found. Exiting..." 
+test -d $BUILDDIR || error "Expected build directory \"$BUILDDIR\" not found. Exiting..." 
 cd $BUILDDIR
 
-if ${clean_build:-}; then 
+if $clean_build; then 
   
    # Want to be damn sure of we're in the right directory, rm -rf * is no joke...
 
@@ -131,7 +129,7 @@ else
   UB_CMAKE="cmake"
 fi
 
-if ${cmake_trace:-}; then
+if $cmake_trace; then
   UB_CMAKE="${UB_CMAKE} --trace"
 fi
 

--- a/bin/dbt-create.sh
+++ b/bin/dbt-create.sh
@@ -1,6 +1,4 @@
-#!/usr/bin/env bash
-set -o errexit -o nounset -o pipefail
-IFS=$'\n\t\v'
+#!/bin/env bash
 
 function print_usage() {
                 cat << EOU
@@ -81,7 +79,7 @@ RELEASE_PATH=$(realpath -m "${RELEASE_BASEPATH}/${RELEASE}")
 
 test -d ${RELEASE_PATH} || error  "Release path '${RELEASE_PATH}' does not exist. Exiting..."
 
-if [[ -n ${DBT_SETUP_BUILD_ENVIRONMENT_SCRIPT_SOURCED:-} ]]; then
+if [[ -n $DBT_SETUP_BUILD_ENVIRONMENT_SCRIPT_SOURCED ]]; then
     error "$( cat<<EOF
 
 It appears you're trying to run this script from an environment

--- a/dbt-setup-env.sh
+++ b/dbt-setup-env.sh
@@ -1,19 +1,10 @@
-#!/usr/bin/env bash # for the fish shell fans
-set -o pipefail
-set -o nounset
-set +o errexit # we expect this file to be `source`d, prevent exiting user shell
-
 #------------------------------------------------------------------------------
 HERE=$(cd $(dirname $(readlink -f ${BASH_SOURCE})) && pwd)
 
 export DBT_ROOT=${HERE}
-# docker does not set these, UPS relies on them
-export USER=${USER:-$(whoami)}
-export HOSTNAME=${HOSTNAME:-$(hostname)}
 
 # Import add_many_paths function
 source ${DBT_ROOT}/scripts/dbt-setup-tools.sh
-abort_if_not_sourced
 
 add_many_paths PATH ${DBT_ROOT}/bin ${DBT_ROOT}/scripts
 export PATH

--- a/scripts/dbt-create-pyvenv.sh
+++ b/scripts/dbt-create-pyvenv.sh
@@ -1,6 +1,4 @@
-#!/usr/bin/env bash
-set -o errexit -o nounset -o pipefail
-IFS=$'\n\t\v'
+#!/bin/env bash
 
 #------------------------------------------------------------------------------
 HERE=$(cd $(dirname $(readlink -f ${BASH_SOURCE})) && pwd)
@@ -29,7 +27,7 @@ timenow="date \"+%D %T\""
 ###
 # Check if inside a virtualenv already
 ###
-if [[ "${VIRTUAL_ENV:-""}" != "" ]]
+if [[ "$VIRTUAL_ENV" != "" ]]
 then
   error "You are already in a virtual env. Please deactivate first. Exiting..."
 fi
@@ -38,7 +36,7 @@ fi
 # Check if python from cvmfs has been set up.
 # Add version check in the future.
 ###
-if [ -z "${SETUP_PYTHON:-}" ]; then    
+if [ -z "$SETUP_PYTHON" ]; then    
     echo -e "INFO [`eval $timenow`]: Python UPS product is not set, setting it from cvmfs now."
     # Source the area settings to determine what area where to get python from
     source ${DBT_AREA_ROOT}/${DBT_AREA_FILE}
@@ -69,7 +67,7 @@ fi
 
 source ${DBT_AREA_ROOT}/${DBT_VENV}/bin/activate
 
-if [[ "${VIRTUAL_ENV:-""}" == "" ]]
+if [[ "$VIRTUAL_ENV" == "" ]]
 then
   error "Failed to load the virtual env. Exiting..." 
 fi

--- a/scripts/dbt-setup-build-environment.sh
+++ b/scripts/dbt-setup-build-environment.sh
@@ -1,8 +1,3 @@
-#!/usr/bin/env bash
-set -o pipefail
-set -o nounset
-set +o errexit # we expect this file to be `source`d, prevent exiting user shell
-
 #------------------------------------------------------------------------------
 HERE=$(cd $(dirname $(readlink -f ${BASH_SOURCE})) && pwd)
 
@@ -68,3 +63,6 @@ fi
 export DBT_SETUP_BUILD_ENVIRONMENT_SCRIPT_SOURCED=1
 echo "This script has been sourced successfully"
 echo
+
+
+

--- a/scripts/dbt-setup-runtime-environment.sh
+++ b/scripts/dbt-setup-runtime-environment.sh
@@ -1,14 +1,8 @@
-#!/usr/bin/env bash
-set -o pipefail
-set -o nounset
-set +o errexit # we expect this file to be `source`d, prevent exiting user shell
-
 #------------------------------------------------------------------------------
 HERE=$(cd $(dirname $(readlink -f ${BASH_SOURCE})) && pwd)
 
 # Import find_work_area function
 source ${HERE}/dbt-setup-tools.sh
-abort_if_not_sourced
 
 DBT_AREA_ROOT=$(find_work_area)
 
@@ -26,7 +20,7 @@ EOF
 
 fi
 
-if [[ -z ${DBT_SETUP_BUILD_ENVIRONMENT_SCRIPT_SOURCED:-} ]]; then
+if [[ -z $DBT_SETUP_BUILD_ENVIRONMENT_SCRIPT_SOURCED ]]; then
       type dbt-setup-build-environment > /dev/null
       retval="$?"
 

--- a/scripts/dbt-setup-tools.sh
+++ b/scripts/dbt-setup-tools.sh
@@ -14,39 +14,17 @@ COL_NULL="\e[0m"
 source ${HERE}/dbt-setup-constants.sh
 
 #------------------------------------------------------------------------------
-# Print an error message and exit if the user did not run your script using
-# `source yourscript.sh` (but rather `bash yourscript.sh` or similar)
-# This command traces back up to the original user command, it does not
-# consider 'inbetween' sourced or not-sourced scripts
-function abort_if_not_sourced() {
-  if [[ "$(basename ${BASH_SOURCE[-1]})" == "$(basename $0)" ]]; then
-    >&2 echo -e "${COL_RED}Please run me by sourcing me${COL_NULL}"
-    >&2 echo "source $0"
-    exit 1
-  fi
-}
-#------------------------------------------------------------------------------
-
-
-#------------------------------------------------------------------------------
 function setup_ups_product_areas() {
   
-  if [ -z "${dune_products_dirs:-}" ]; then
+  if [ -z "${dune_products_dirs}" ]; then
     echo "UPS product directories variable (dune_products_dirs) undefined; no products areas will be set up" >&2
   fi
 
   for proddir in ${dune_products_dirs[@]}; do
-      # these setup scripts are not controlled by us
-      # they fail when setting 'safe mode' options like the ones being disabled just below
-      # they are re-enabled after, if they were set
-      prevbashoptions="$(set +o)"
-      set +o errexit +o nounset +o pipefail
       source ${proddir}/setup
       if ! [[ $? -eq 0 ]]; then
 	  echo "Warning: unable to set up products area \"${proddir}\"" >&2
       fi
-      # re-enable options that we may have disabled
-      eval "$prevbashoptions"
   done
 
 }
@@ -56,12 +34,12 @@ function setup_ups_product_areas() {
 #------------------------------------------------------------------------------
 function setup_ups_products() {
 
+  if [ -z "${dune_products}" ]; then
+    echo "UPS products variable (dune_products_dirs) undefined";
+  fi
+
   # And another function here?
   setup_returns=""
-
-  if [ -z "${dune_products}" ]; then
-    >&2 echo "UPS products variable (dune_products_dirs) undefined";
-  fi
 
   for prod in "${dune_products[@]}"; do
       prodArr=(${prod})
@@ -71,29 +49,8 @@ function setup_ups_products() {
           setup_cmd="${setup_cmd} -q ${prodArr[2]}"
       fi
       echo $setup_cmd
-      # these setup scripts are not controlled by us
-      # they fail when setting 'safe mode' options like the ones being disabled just below
-      # they are re-enabled after, if they were set
-      prevbashoptions="$(set +o)"
-      set +o errexit +o nounset +o pipefail
-      # setup command will silently fail (return 0)
-      # but setup also produces no output on success, we can check for this
-      # but setup also fails when running in a subshell (yes)
-      # any pipes make bash run your command in a subshell
-      # hence the 'dumb' tmp file approach
-      tmpfile=$(mktemp)
-      ${setup_cmd} > $tmpfile 2>&1
-      exitcode="$?"
-      output="$(cat $tmpfile)"
-      if [[ ! "$(cat $tmpfile)" == "" ]]; then
-        >&2 echo "detected failure in setup output:"
-        >&2 echo "$output"
-        exitcode="1"
-      fi
-      rm -rf "$tmpfile"
-      setup_returns=$setup_returns"$exitcode "
-      # re-enable options that we may have disabled
-      eval "$prevbashoptions"
+      ${setup_cmd}
+      setup_returns=$setup_returns"$? "
   done
 }
 #------------------------------------------------------------------------------
@@ -115,9 +72,7 @@ function find_work_area() {
     SEARCH_PATH=$(dirname ${SEARCH_PATH})
   done
 
-  if [[ -n "${WA_PATH:-}" ]]; then
-    echo $(dirname ${WA_PATH})
-  fi
+  echo $(dirname ${WA_PATH})
 }
 #------------------------------------------------------------------------------
 
@@ -151,7 +106,6 @@ function add_path() {
     #   This form expands to nothing if the parameter is unset or empty. If it
     #   is set, it does not expand to the parameter's value, but to some text
     #   you can specify
-    # https://tldp.org/LDP/abs/html/parameter-substitution.html
     PATH_VAL="$PATH_ADD${PATH_VAL:+":$PATH_VAL"}"
 
     echo -e "${COL_BLUE}Added ${PATH_ADD} to ${PATH_NAME}${COL_NULL}"
@@ -175,13 +129,10 @@ function add_many_paths() {
 #------------------------------------------------------------------------------
 function error_preface() {
 
-  # most likely this file is sourced and used in another script
-  # get path of parent script (i.e. not 'dbt-setup-tools.sh')
   for dbt_file in "${BASH_SOURCE[@]}"; do
-    # ${BASH_SOURCE[0]} is always the name of this file
     if ! [[ "${BASH_SOURCE[0]}" =~ "$dbt_file" ]]; then
 	    break
-	  fi
+	   fi
   done
 
   dbt_file=$( basename $dbt_file )
@@ -197,8 +148,7 @@ function error() {
     error_preface
     echo -e " ${COL_RED} ${1} ${COL_NULL} " >&2
 
-    # if this file was not sourced, exit
-    if [[ "$(basename ${BASH_SOURCE[-1]})" == "$(basename $0)" ]]; then
+    if [[ -x ${BASH_SOURCE[-1]} ]]; then
         exit 100
     fi
 }


### PR DESCRIPTION
Reverts DUNE-DAQ/daq-buildtools#96

Alas the guards implemented in #96 interfere with user shells and bash history.
Rolling back the merge waiting to find a solution to avoid side effects.