### PR TITLE
Loading runtime environment before running unittests.

### DIFF
--- a/bin/dbt-build.sh
+++ b/bin/dbt-build.sh
@@ -317,6 +317,8 @@ if $run_tests ; then
 
   cd $BUILDDIR
 
+  source ${DBT_ROOT}/scripts/dbt-setup-runtime-environment.sh
+
   if [[ -z $package_to_test ]]; then
     package_list=$( find . -mindepth 1 -maxdepth 1 -type d -not -name CMakeFiles )
   else

--- a/dbt-setup-env.sh
+++ b/dbt-setup-env.sh
@@ -12,5 +12,3 @@ export PATH
 alias dbt-setup-build-environment="source ${DBT_ROOT}/scripts/dbt-setup-build-environment.sh"
 alias dbt-setup-runtime-environment="source ${DBT_ROOT}/scripts/dbt-setup-runtime-environment.sh"
 echo -e "${COL_GREEN}DBT setuptools loaded${COL_NULL}"
-
-


### PR DESCRIPTION
See DUNE-DAQ/daq-cmake#29 for context.