### PR TITLE
New dbt-settings data format 

### DIFF
--- a/bin/dbt-build.sh
+++ b/bin/dbt-build.sh
@@ -42,21 +42,26 @@ while ((i_arg < $#)); do
   i_arg=$((i_arg + 1))
 
   if [[ "$arg" == "--help" ]]; then
-    echo "Usage: "./$( basename $0 )" --clean --debug --unittest <optional package name> --lint <optional package name> --install --verbose --help "
-    echo
-    echo " --clean means the contents of ./build are deleted and CMake's config+generate+build stages are run"
-    echo " --debug means you want to build your software with optimizations off and debugging info on"
-    echo " --unittest means that unit test executables found in ./build/<optional package name>/unittest are run, or all unit tests in ./build/*/unittest are run if no package name is provided"
-    echo " --lint means you check for deviations in ./sourcecode/<optional package name> from the DUNE style guide, https://github.com/DUNE-DAQ/styleguide/blob/develop/dune-daq-cppguide.md, or deviations in all local repos if no package name is provided"
-    echo " --install means that you want the code from your package(s) installed in the directory which was pointed to by the DBT_INSTALL_DIR environment variable before the most recent clean build"
-    echo " --verbose means that you want verbose output from the compiler"
-    echo " --cmake-trace enable cmake tracing"
-    echo " --cmake-graphviz geneates a target dependency graph"
+    cat << EOF
 
-    echo
-    echo "All arguments are optional. With no arguments, CMake will typically just run "
-    echo "build, unless build/CMakeCache.txt is missing"
-    echo
+      Usage: "./$( basename $0 )" --clean --debug --jobs <number parallel build jobs> --unittest <optional package name> --lint <optional package name> --install --verbose --help 
+      
+       --clean means the contents of ./build are deleted and CMake's config+generate+build stages are run
+       --debug means you want to build your software with optimizations off and debugging info on
+       --jobs means you want to specify the number of jobs used by cmake to build the project
+       --unittest means that unit test executables found in ./build/<optional package name>/unittest are run, or all unit tests in ./build/*/unittest are run if no package name is provided
+       --lint means you check for deviations in ./sourcecode/<optional package name> from the DUNE style guide, https://github.com/DUNE-DAQ/styleguide/blob/develop/dune-daq-cppguide.md, or deviations in all local repos if no package name is provided
+       --install means that you want the code from your package(s) installed in the directory which was pointed to by the DBT_INSTALL_DIR environment variable before the most recent clean build
+       --verbose means that you want verbose output from the compiler
+       --cmake-trace enable cmake tracing
+       --cmake-graphviz geneates a target dependency graph
+
+    
+    All arguments are optional. With no arguments, CMake will typically just run 
+    build, unless build/CMakeCache.txt is missing    
+    
+EOF
+
     exit 0    
 
   elif [[ "$arg" == "--clean" ]]; then

--- a/bin/dbt-create.sh
+++ b/bin/dbt-create.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # set -o errexit
-set -o nounset
+# set -o nounset
 # set -o pipefail
 
 function print_usage() {
@@ -45,7 +45,7 @@ PY_PKGLIST="pyvenv_requirements.txt"
 DAQ_BUILDORDER_PKGLIST="dbt-build-order.cmake"
 
 # We use "$@" instead of $* to preserve argument-boundary information
-options=$(getopt -o 'hlr:e' -l 'help,list,release-base-path:,disable-edit-check' -- "$@") || exit
+options=$(getopt -o 'hlr:' -l 'help,list,release-base-path:' -- "$@") || exit
 eval "set -- $options"
 
 while true; do
@@ -61,7 +61,9 @@ while true; do
             print_usage
             exit 0;;
         (--)  shift; break;;
-        (*)   exit 1;;           # error
+        (*) 
+            echo "ERROR $@"  
+            exit 1;;           # error
     esac
 done
 

--- a/scripts/dbt-create-pyvenv.sh
+++ b/scripts/dbt-create-pyvenv.sh
@@ -45,7 +45,8 @@ if [ -z "$SETUP_PYTHON" ]; then
 
     setup_ups_product_areas
 
-    setup -B python ${dune_python_version}
+    # setup -B python ${dune_python_version}
+    setup_ups_products dune_systems
     test $? -eq 0 || error "The \"setup -B python ${dune_python_version}\" call failed. Exiting..." 
 
 else

--- a/scripts/dbt-setup-build-environment.sh
+++ b/scripts/dbt-setup-build-environment.sh
@@ -48,10 +48,17 @@ then
   return 11
 fi
 
+all_setup_return=""
+setup_ups_products dune_devtools
+all_setup_return="${setup_ups_returns} ${all_setup_return}"
+setup_ups_products dune_systems
+all_setup_return="${setup_ups_returns} ${all_setup_return}"
+setup_ups_products dune_externals
+all_setup_return="${setup_ups_returns} ${all_setup_return}"
+setup_ups_products dune_daqpackages
+all_setup_return="${setup_ups_returns} ${all_setup_return}"
 
-setup_ups_products
-
-export DBT_INSTALL_DIR=${DBT_AREA_ROOT}/install
+echo "'${all_setup_return}'"
 
 if ! [[ "$setup_returns" =~ [1-9] ]]; then
   echo "All setup calls on the packages returned 0, indicative of success"
@@ -59,6 +66,8 @@ else
   error "At least one of the required packages this script attempted to set up didn't set up correctly. Returning..." 
   return 1
 fi
+
+export DBT_INSTALL_DIR=${DBT_AREA_ROOT}/install
 
 export DBT_SETUP_BUILD_ENVIRONMENT_SCRIPT_SOURCED=1
 echo "This script has been sourced successfully"

--- a/scripts/dbt-setup-tools.sh
+++ b/scripts/dbt-setup-tools.sh
@@ -34,14 +34,17 @@ function setup_ups_product_areas() {
 #------------------------------------------------------------------------------
 function setup_ups_products() {
 
-  if [ -z "${dune_products}" ]; then
-    echo "UPS products variable (dune_products_dirs) undefined";
+  if [ -z "${1}" ]; then
+    echo "Usage: setup_ups_products <product variable>";
   fi
+
+  product_set_name=${1}
+  product_set="${product_set_name}[@]"
 
   # And another function here?
   setup_returns=""
 
-  for prod in "${dune_products[@]}"; do
+  for prod in "${!product_set}"; do
       prodArr=(${prod})
 
       setup_cmd="setup -B ${prodArr[0]//-/_} ${prodArr[1]}"
@@ -52,6 +55,8 @@ function setup_ups_products() {
       ${setup_cmd}
       setup_returns=$setup_returns"$? "
   done
+
+  echo "setup_returns ${setup_returns}"
 }
 #------------------------------------------------------------------------------
 


### PR DESCRIPTION
Introduces the splitting of ups packages between system (gcc, python), devtools (cmake, etc...), externals (zmq...) and daq packages.
Closes #97 and #91