### PR TITLE
use functions (issue#114); consider CDPATH; flush=True

### DIFF
--- a/bin/dbt-create.sh
+++ b/bin/dbt-create.sh
@@ -101,7 +101,7 @@ if [ ! -d "${TARGETDIR}" ] ; then
     mkdir -p ${TARGETDIR}
 fi
 
-TARGETDIR=$(cd $TARGETDIR && pwd)
+TARGETDIR=$(cd $TARGETDIR >/dev/null && pwd)  # redirect cd to /dev/null b/c CDPATH may be used
 
 cd ${TARGETDIR}
 

--- a/dbt-setup-env.sh
+++ b/dbt-setup-env.sh
@@ -1,3 +1,4 @@
+#!/bin/sh
 #------------------------------------------------------------------------------
 HERE=$(cd $(dirname $(readlink -f ${BASH_SOURCE})) && pwd)
 
@@ -9,6 +10,6 @@ source ${DBT_ROOT}/scripts/dbt-setup-tools.sh
 add_many_paths PATH ${DBT_ROOT}/bin ${DBT_ROOT}/scripts
 export PATH
 
-alias dbt-setup-build-environment="source ${DBT_ROOT}/scripts/dbt-setup-build-environment.sh"
-alias dbt-setup-runtime-environment="source ${DBT_ROOT}/scripts/dbt-setup-runtime-environment.sh"
+dbt-setup-build-environment() { source ${DBT_ROOT}/scripts/dbt-setup-build-environment.sh; }
+dbt-setup-runtime-environment() { source ${DBT_ROOT}/scripts/dbt-setup-runtime-environment.sh; }
 echo -e "${COL_GREEN}DBT setuptools loaded${COL_NULL}"

--- a/scripts/pytee.py
+++ b/scripts/pytee.py
@@ -48,7 +48,7 @@ def run(cmd, args, log):
         # print(index)
         if index == 0:
             text=process.before.decode('utf-8')
-            print(text)
+            print(text,flush=True)
             if log:
                 print(text, file=logfile)
 
@@ -56,7 +56,7 @@ def run(cmd, args, log):
             if not process.before:
                 continue
             text=process.before.decode('utf-8')
-            print(text)
+            print(text,flush=True)
             if log:
                 print(text, file=logfile)
         else:


### PR DESCRIPTION
use shell functions instead of aliases -- to allow the use of a wrapper function that contains all the steps.
redirect `cd` output to dev/null in case CDPATH is set and undesirable stdout output results.
add flush=True to prevent output from being buffered when script is piped into tee (or other adjustments to stdout).