### PR TITLE
#130: Adding handles to switch from production releases and nightlies

### DIFF
--- a/bin/dbt-create.sh
+++ b/bin/dbt-create.sh
@@ -20,6 +20,7 @@ To list the available DUNE DAQ releases:
 Arguments and options:
 
     dunedaq-release: is the name of the release the new work area will be based on (e.g. dunedaq-v2.0.0)
+    -n/--nightly: switch to nightly releases
     -l/--list: show the list of available releases
     -r/--release-path: is the path to the release archive (RELEASE_BASEPATH var; default: /cvmfs/dune.opensciencegrid.org/dunedaq/DUNE/releases)
 
@@ -28,9 +29,12 @@ EOU
 
 
 EMPTY_DIR_CHECK=true
-RELEASE_BASEPATH="/cvmfs/dune.opensciencegrid.org/dunedaq/DUNE/releases"
+PROD_BASEPATH="/cvmfs/dunedaq.opensciencegrid.org/releases"
+NIGHTLY_BASEPATH="/cvmfs/dunedaq-development.opensciencegrid.org/nightly"
+CUSTOM_BASEPATH=""
 # TARGETDIR=""
 SHOW_RELEASE_LIST=false
+NIGHTLY=false
 
 # Define usage function here
 
@@ -45,17 +49,20 @@ PY_PKGLIST="pyvenv_requirements.txt"
 DAQ_BUILDORDER_PKGLIST="dbt-build-order.cmake"
 
 # We use "$@" instead of $* to preserve argument-boundary information
-options=$(getopt -o 'hlr:' -l ',help,list,release-base-path:' -- "$@") || exit
+options=$(getopt -o 'hnlr:' -l ',help,nightly,list,release-base-path:' -- "$@") || exit
 eval "set -- $options"
 
 while true; do
     case $1 in
+        (-n|--nightly)
+            NIGHTLY=true
+            shift;;
         (-l|--list)
             # List available releases
             SHOW_RELEASE_LIST=true
             shift;;
         (-r|--release-path)
-            RELEASE_BASEPATH=$2
+            CUSTOM_BASEPATH=$2
             shift 2;;
         (-h|--help)
             print_usage
@@ -69,12 +76,20 @@ done
 
 ARGS=("$@")
 
+if [[ ! -z "${CUSTOM_BASEPATH}" ]]; then
+    RELEASE_BASEPATH="${CUSTOM_BASEPATH}"
+elif [ "${NIGHTLY}" = false ]; then
+    RELEASE_BASEPATH="${PROD_BASEPATH}"
+else
+    RELEASE_BASEPATH="${NIGHTLY_BASEPATH}"
+fi
+
 if [[ "${SHOW_RELEASE_LIST}" == true ]]; then
     list_releases
     exit 0;
 fi
 
-test ${#ARGS[@]} -eq 2 || error "Wrong number of arguments. Try '$( basename $0 ) -h' for more information." 
+test ${#ARGS[@]} -eq 2 || error "Wrong number of arguments. Run '$( basename $0 ) -h' for more information." 
 
 
 RELEASE=${ARGS[0]}

--- a/scripts/dbt-setup-tools.sh
+++ b/scripts/dbt-setup-tools.sh
@@ -91,8 +91,10 @@ function find_work_area() {
 #------------------------------------------------------------------------------
 function list_releases() {
     # How? RELEASE_BASEPATH subdirs matching some condition? i.e. dunedaq_area.sh file in it?
-    FOUND_RELEASES=($(find ${RELEASE_BASEPATH} -maxdepth 2 -name ${UPS_PKGLIST} -printf '%h '))
-    for rel in "${FOUND_RELEASES[@]}"; do
+    FOUND_RELEASES=($(find -L ${RELEASE_BASEPATH} -maxdepth 2 -name ${UPS_PKGLIST} -printf '%h '))
+    readarray -t SORTED_RELEASES < <(printf '%s\n' "${FOUND_RELEASES[@]}" | sort)
+
+    for rel in "${SORTED_RELEASES[@]}"; do
         echo " - $(basename ${rel})"
     done 
 }


### PR DESCRIPTION
This PR adds to `dbt-create.sh` the capability to switch to nightly releases.
See #130 