### PR TITLE
#123: Final (cough) tweaks to `dbt-work-env` and `dbt-build.sh`

### DIFF
--- a/bin/dbt-build.sh
+++ b/bin/dbt-build.sh
@@ -382,7 +382,7 @@ if $run_tests ; then
       continue
     fi
 
-    if [[ -z $BOOST_TEST_LOG_LEVEL ]]; then
+    if [[ -z ${BOOST_TEST_LOG_LEVEL:-} ]]; then
        export BOOST_TEST_LOG_LEVEL=all
     fi
 

--- a/bin/dbt-build.sh
+++ b/bin/dbt-build.sh
@@ -130,76 +130,6 @@ if [[ ! -z "${ARGS:-}" ]]; then
     error "Unknown arguments '${ARGS[@]}' provided; run with \" --help\" to see valid options. Exiting..."  
 fi
 
-# while ((i_arg < $#)); do
-
-#   arg=${args[$i_arg]}
-#   nextarg=
-#   if ((i_arg + 1 < $#)); then
-#       nextarg=${args[$((i_arg+1))]}
-#   fi
-#   i_arg=$((i_arg + 1))
-
-#   if [[ "$arg" == "--help" ]]; then
-#     cat << EOF
-
-#       Usage: "./$( basename $0 )" --clean --debug --jobs <number parallel build jobs> --unittest <optional package name> --lint <optional package name> --install --verbose --help 
-      
-#        --clean means the contents of ./build are deleted and CMake's config+generate+build stages are run
-#        --debug means you want to build your software with optimizations off and debugging info on
-#        --jobs means you want to specify the number of jobs used by cmake to build the project
-#        --unittest means that unit test executables found in ./build/<optional package name>/unittest are run, or all unit tests in ./build/*/unittest are run if no package name is provided
-#        --lint means you check for deviations in ./sourcecode/<optional package name> from the DUNE style guide, https://github.com/DUNE-DAQ/styleguide/blob/develop/dune-daq-cppguide.md, or deviations in all local repos if no package name is provided
-#        --install means that you want the code from your package(s) installed in the directory which was pointed to by the DBT_INSTALL_DIR environment variable before the most recent clean build
-#        --verbose means that you want verbose output from the compiler
-#        --cmake-trace enable cmake tracing
-#        --cmake-graphviz geneates a target dependency graph
-
-    
-#     All arguments are optional. With no arguments, CMake will typically just run 
-#     build, unless build/CMakeCache.txt is missing    
-    
-# EOF
-
-#     exit 0    
-
-#   elif [[ "$arg" == "--clean" ]]; then
-#     clean_build=true
-#   elif [[ "$arg" == "--debug" ]]; then
-#     debug_build=true
-#   elif [[ "$arg" == "--unittest" ]]; then
-#     run_tests=true
-#     if [[ -n ${nextarg:-} && "$nextarg" =~ ^[^\-] ]]; then
-#         package_to_test=$nextarg
-#         i_arg=$((i_arg + 1))
-#     fi
-#   elif [[ "$arg" == "--lint" ]]; then
-#     lint=true
-#     if [[ -n ${nextarg:-} && "$nextarg" =~ ^[^\-] ]]; then
-#         package_to_lint=$nextarg
-#         i_arg=$((i_arg + 1))
-#     fi
-#   elif [[ "$arg" == "--verbose" ]]; then
-#     cpp_verbose=true
-#   elif [[ "$arg" == "--cmake-trace" ]]; then
-#     cmake_trace=true
-#   elif [[ "$arg" == "--cmake-graphviz" ]]; then
-#     cmake_graphviz=true
-#   elif [[ "$arg" == "--jobs" ]]; then
-#     if [[ -n ${nextarg:-} && "$nextarg" =~ ^[^\-] ]]; then
-#         n_jobs=$nextarg
-#         i_arg=$((i_arg + 1))
-#     fi
-#   elif [[ "$arg" == "--pkgname" ]]; then
-#     error "Use of --pkgname is deprecated; run with \" --help\" to see valid options. Exiting..."
-#   elif [[ "$arg" == "--install" ]]; then
-#     perform_install=true
-
-#   else
-#     error "Unknown argument provided; run with \" --help\" to see valid options. Exiting..."
-#   fi
-# 
-# done
-
 if [[ -z ${DBT_WORKAREA_ENV_SCRIPT_SOURCED:-} ]]; then
  
 error "$( cat<<EOF
@@ -435,17 +365,15 @@ if $run_tests ; then
 
   cd $BUILDDIR
 
-  source ${DBT_ROOT}/scripts/dbt-workarea-env.sh --refresh
-
   if [[ -z $package_to_test ]]; then
-    package_list=$( find . -mindepth 1 -maxdepth 1 -type d -not -name CMakeFiles )
+    package_list=$( find -L . -mindepth 1 -maxdepth 1 -type d -not -name CMakeFiles )
   else
-          package_list=$package_to_test
+    package_list=$package_to_test
   fi
 
   for pkgname in $package_list ; do
 
-    unittestdirs=$( find $BUILDDIR/$pkgname -type d -name "unittest" -not -regex ".*CMakeFiles.*" )
+    unittestdirs=$( find -L $BUILDDIR/$pkgname -type d -name "unittest" -not -regex ".*CMakeFiles.*" )
 
     if [[ -z $unittestdirs ]]; then
       echo

--- a/scripts/dbt-workarea-env.sh
+++ b/scripts/dbt-workarea-env.sh
@@ -74,6 +74,11 @@ if [[ ("${REFRESH_UPS}" == "false" &&  -z "${DBT_UPS_SETUP_DONE}") || "${REFRESH
         echo -e "${COL_GREEN}This script hasn't yet been sourced (successfully) in this shell; setting up the build environment${COL_RESET}\n"
     else
         echo -e "${COL_GREEN}Refreshing UPS package setup${COL_RESET}\n"
+        # Clean up
+        echo -e "${COL_BLUE}Deactivating python environment${COL_RESET}\n"
+        deactivate
+        echo -e "${COL_BLUE}Running ups un-setup${COL_RESET}\n"
+        unsetup_all
     fi
 
     # 1. Load the UPS area information from the local area file
@@ -146,11 +151,11 @@ for p in ${DBT_PACKAGES}; do
     pkg_share="${PNAME//-/_}_SHARE"
     declare -xg "${pkg_share}"="${BUILD_DIR}/${p}"
 
-    add_many_paths_if_exist PATH "${PKG_BLD_PATH}/apps" "${PKG_BLD_PATH}/scripts" "${PKG_BLD_PATH}/test/apps" "${PKG_BLD_PATH}/test/scripts"
-    add_many_paths_if_exist PYTHONPATH "${PKG_BLD_PATH}/python"
-    add_many_paths_if_exist LD_LIBRARY_PATH "${PKG_BLD_PATH}/src"  "${PKG_BLD_PATH}/plugins"  "${PKG_BLD_PATH}/test/plugins"
-    add_many_paths_if_exist CET_PLUGIN_PATH "${PKG_BLD_PATH}/plugins" "${PKG_BLD_PATH}/test/plugins"
-    add_many_paths_if_exist DUNEDAQ_SHARE_PATH  "${PKG_BLD_PATH}" "${PKG_BLD_PATH}/test/share"
+    add_many_paths PATH "${PKG_BLD_PATH}/apps" "${PKG_BLD_PATH}/scripts" "${PKG_BLD_PATH}/test/apps" "${PKG_BLD_PATH}/test/scripts"
+    add_many_paths PYTHONPATH "${PKG_BLD_PATH}/python"
+    add_many_paths LD_LIBRARY_PATH "${PKG_BLD_PATH}/src"  "${PKG_BLD_PATH}/plugins"  "${PKG_BLD_PATH}/test/plugins"
+    add_many_paths CET_PLUGIN_PATH "${PKG_BLD_PATH}/plugins" "${PKG_BLD_PATH}/test/plugins"
+    add_many_paths DUNEDAQ_SHARE_PATH  "${PKG_BLD_PATH}" "${PKG_BLD_PATH}/test/share"
 done
 
 export PATH PYTHONPATH LD_LIBRARY_PATH CET_PLUGIN_PATH DUNEDAQ_SHARE_PATH


### PR DESCRIPTION
- `--refresh` requires running `unsetup_all` or the env gets corrupted
- Package directories (in `build/` are added tο relevant paths regardless of whether they've been already created)
  This avoids having to re-run `dbt-work-env` after `dbt-build.sh` to get access to the products