### PR TITLE
Johnfreeman/correct python path

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -14,7 +14,7 @@ Simply do:
 ```bash
 git clone http://github.com/DUNE-DAQ/daq-buildtools
 cd daq-buildtools
-git checkout 6fedc102dae1d  # Head of develop on July 16th, includes fix to PYTHONPATH
+git checkout 6e0abcc84b56010 # Head of develop on July 16th, includes fix to PYTHONPATH
 cd ..
 source ./daq-buildtools/env.sh
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,7 +14,7 @@ Simply do:
 ```bash
 git clone http://github.com/DUNE-DAQ/daq-buildtools
 cd daq-buildtools
-git checkout 6fcc0fd539   # Head of develop on July 13th
+git checkout 6fedc102dae1d  # Head of develop on July 16th, includes fix to PYTHONPATH
 cd ..
 source ./daq-buildtools/env.sh
 

--- a/scripts/dbt-workarea-env.sh
+++ b/scripts/dbt-workarea-env.sh
@@ -162,7 +162,7 @@ for p in ${DBT_PACKAGES}; do
     declare -xg "${pkg_share}"="${BUILD_DIR}/${p}"
 
     add_many_paths PATH "${PKG_INSTALL_PATH}/bin" "${PKG_INSTALL_PATH}/test/bin"
-    add_many_paths PYTHONPATH "${PKG_INSTALL_PATH}/lib64/python/${p}"
+    add_many_paths PYTHONPATH "${PKG_INSTALL_PATH}/lib64/python"
     add_many_paths LD_LIBRARY_PATH "${PKG_INSTALL_PATH}/lib64"  "${PKG_INSTALL_PATH}/test/lib64"
     add_many_paths CET_PLUGIN_PATH "${PKG_INSTALL_PATH}/lib64" "${PKG_INSTALL_PATH}/test/lib64"
     add_many_paths DUNEDAQ_SHARE_PATH  "${PKG_INSTALL_PATH}/share" 


### PR DESCRIPTION
Fixes the problem Phil noticed on daq-sw-librarians a little while ago, whereby the PYTHONPATH for a given package installed in a work area had an unnecessary subdirectory appended