### PR TITLE
Fixes env.sh error when previous command has a non-zero return code.

### DIFF
--- a/env.sh
+++ b/env.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-$(return >/dev/null 2>&1)
+$(return 0 >/dev/null 2>&1)
 # What exit code did that give?
 if [ "$?" -ne "0" ]
 then


### PR DESCRIPTION
Forcing `0` return value in the sources/executed check.
Closes #155