### PR TITLE
JCF: when dbt-build.py is run, make sure the log of linter output is …

### DIFF
--- a/bin/dbt-build.py
+++ b/bin/dbt-build.py
@@ -351,7 +351,7 @@ if args.lint:
     sh.date(_out=stringio_obj8)
     datestring=re.sub("[: ]+", "_", stringio_obj8.getvalue().strip())
     
-    lint_log=f"{BASEDIR}/linting_{datestring}.log"
+    lint_log=f"{LOGDIR}/linting_{datestring}.log"
 
     if not os.path.exists("styleguide"):
         rich.print(f"Cloning styleguide into {os.getcwd()} so linting can be applied")


### PR DESCRIPTION
…saved in log/ and not in the base of the work area