### PR TITLE
Johnfreeman/issues 184 185 188 interface improvements

### DIFF
--- a/bin/dbt-build.py
+++ b/bin/dbt-build.py
@@ -76,6 +76,7 @@ parser.add_argument("-i", "--install", action="store_true", help=argparse.SUPPRE
 parser.add_argument("--cmake-msg-lvl", dest="cmake_msg_lvl", help=argparse.SUPPRESS)
 parser.add_argument("--cmake-trace", action="store_true", dest="cmake_trace", help=argparse.SUPPRESS)
 parser.add_argument("--cmake-graphviz", action="store_true", dest="cmake_graphviz", help=argparse.SUPPRESS)
+parser.add_argument("-y", "--yes-to-all", action="store_true", dest="yes_to_all", help=argparse.SUPPRESS)
 
 args = parser.parse_args()
 
@@ -93,6 +94,10 @@ if args.lint:
 if args.install:
     error("Use of -i/--install is deprecated as installation always occurs now; run with \" --help\" to see valid options. Exiting...")
 
+force_clean = False
+if args.yes_to_all:
+    force_clean = True
+
 if "DBT_WORKAREA_ENV_SCRIPT_SOURCED" not in os.environ:
     error("""
 It appears you haven't yet executed "dbt-workarea-env"; please do so before
@@ -106,11 +111,13 @@ os.chdir(BUILDDIR)
 if args.clean_build:
     # Want to be damn sure we're in the right directory, recursive directory removal is no joke...
     if os.path.basename(os.getcwd()) == "build":
-        rich.print(f"""
-Clean build requested, will delete all the contents of build directory \"{os.getcwd()}\".
-If you wish to abort, you have 5 seconds to hit Ctrl-c"
-        """)
-        sleep(5)
+
+        if not force_clean:
+            rich.print(f"""
+    Clean build requested, will delete all the contents of build directory \"{os.getcwd()}\".
+    If you wish to abort, you have 5 seconds to hit Ctrl-c"
+            """)
+            sleep(5)
 
         for filename in os.listdir(os.getcwd()):
             file_path = os.path.join(os.getcwd(), filename)

--- a/bin/dbt-build.py
+++ b/bin/dbt-build.py
@@ -11,7 +11,6 @@ if sys.prefix == sys.base_prefix:
     sys.exit(1)
 
 import argparse
-from colorama import Fore, Style
 import io
 import multiprocessing
 import re
@@ -332,7 +331,7 @@ if run_tests:
         unittestdirs = stringio_obj7.getvalue().split()
 
         if len(unittestdirs) == 0:
-            rich.print("{}No unit tests have been written for {}{}".format(Fore.RED, pkgname, Style.RESET_ALL), file = sys.stderr)
+            rich.print(f"[red]No unit tests have been written for {pkgname}[/red]", file = sys.stderr)
             continue
 
         if not "BOOST_TEST_LOG_LEVEL" in os.environ:
@@ -366,7 +365,7 @@ RUNNING UNIT TESTS IN {unittestdir}
                     pytee.run("echo", echo_result.split(), test_log_summary)
                     num_unit_tests += 1
 
-            rich.print("{}Testing complete for package \"{}\". Ran {} unit test suites.{}".format(Fore.YELLOW, pkgname, num_unit_tests, Style.RESET_ALL))
+            rich.print(f"[yellow]Testing complete for package \"{pkgname}\". Ran {num_unit_tests} unit test suites.[/yellow]")
             rich.print("")
             rich.print(f"Test summary can be found in {test_log_summary}.")
             rich.print(f"Detailed test results are saved under {test_log_dir}.")

--- a/bin/dbt-build.py
+++ b/bin/dbt-build.py
@@ -194,7 +194,7 @@ This script ran into a problem running
 
 {fullcmd}
 
-from {BUILDDIR} (i.e., CMake's config+generate stages).
+from {BUILDDIR} (i.e., CMake's build file config+generate stages).
 Scroll up for details or look at the build log via
 
 less -R {BUILDDIR}
@@ -204,7 +204,7 @@ Exiting...
 """)
 
 else:
-    rich.print(f"The config+generate stage was skipped as CMakeCache.txt was already found in {BUILDDIR}")
+    rich.print(f"The CMake build file config+generate stage was skipped as CMakeCache.txt was already found in {BUILDDIR}")
 
 if args.cmake_graphviz:
     output = sh.cmake(["--graphviz=graphviz/targets.dot", "."])
@@ -396,11 +396,11 @@ if args.lint:
 
 rich.print("")
 if cfggentime is not None:
-    rich.print(f"CMake's config+generate stages took {cfggentime} seconds")
+    rich.print(f"CMake's build file config+generate stages took {cfggentime} seconds")
     rich.print(f"Start time: {starttime_cfggen_d}")
     rich.print(f"End time:   {endtime_cfggen_d}")
 else:
-    rich.print(f"CMake's config+generate stages were skipped as the needed build files already existed")
+    rich.print(f"CMake's build file config+generate stages were skipped as the needed build files already existed")
 
 rich.print("")
 rich.print(f"CMake's build stage took {buildtime} seconds")

--- a/bin/dbt-build.py
+++ b/bin/dbt-build.py
@@ -152,9 +152,10 @@ running_config_and_generate=False
 if not os.path.exists("CMakeCache.txt"):
     running_config_and_generate = True
 
-    generator_arg=""
-    if "SETUP_NINJA" in os.environ:
-        generator_arg="-G Ninja"
+    try:
+        re.search(r"^/cvmfs", sh.which("ninja"))
+    except:
+        error("Ninja seems to be missing. The \"which ninja\" command did not yield an executable in the /cvmfs area. Exiting...")
 
     stringio_obj3 = io.StringIO()
     the_which_cmd = sh.Command("which")  # Needed because of a complex alias, at least on mu2edaq
@@ -172,7 +173,7 @@ if not os.path.exists("CMakeCache.txt"):
     if args.cmake_msg_lvl:
         cmake_msg_lvl = args.cmake_msg_lvl
 
-    fullcmd="{} -DCMAKE_MESSAGE_LOG_LEVEL={} -DMOO_CMD={} -DDBT_ROOT={} -DDBT_DEBUG={} -DCMAKE_INSTALL_PREFIX={} {} {}".format(cmake, cmake_msg_lvl, moo_path, os.environ["DBT_ROOT"], debug_build, os.environ["DBT_INSTALL_DIR"], generator_arg, SRCDIR)
+    fullcmd="{} -DCMAKE_MESSAGE_LOG_LEVEL={} -DMOO_CMD={} -DDBT_ROOT={} -DDBT_DEBUG={} -DCMAKE_INSTALL_PREFIX={} -G Ninja {}".format(cmake, cmake_msg_lvl, moo_path, os.environ["DBT_ROOT"], debug_build, os.environ["DBT_INSTALL_DIR"], SRCDIR)
 
     rich.print(f"Executing '{fullcmd}'")
     retval=pytee.run(fullcmd.split(" ")[0], fullcmd.split(" ")[1:], build_log)

--- a/bin/dbt-build.py
+++ b/bin/dbt-build.py
@@ -423,8 +423,8 @@ Automated code linting results can be found in the following directory:
 """
 
 rich.print(f"""
-This script is ending normally. This implies your code successfully compiled; you can
-either scroll up or run the following to see build details:
+This script is ending normally. This implies your code successfully compiled; to see
+build details you can either scroll up or run the following:
 
 less -R {build_log}
 


### PR DESCRIPTION
From John:

The branch `johnfreeman/issues_184_185_188_interface_improvements` is ready for review. There’s no official PR because it’s meant to be `merged into johnfreeman/issue161_spack`, not develop . `daq-buildtools` on this branch does the following:
* Provides real-time output of dbt-clone-pyvenv.sh and dbt-create-pyvenv.sh to screen (Pengfei mentioned this as an issue yesterday)
* Uses Alessandro’s proposed fix to get rich.print to display colored text properly
* Uses Ninja to build, and issues an error if Ninja isn’t found
* Adds a summary at the end of of dbt-build.py which covers where logfiles for build, unittest and linting can be found, as well as the time the build took