### PR TITLE
Johnfreeman/fix last successful arg

### DIFF
--- a/scripts/dbt-setup-release.sh
+++ b/scripts/dbt-setup-release.sh
@@ -113,7 +113,18 @@ EOF
 fi
 
 spack_setup_env
+retval=$?
+if [[ "$retval" != "0" ]]; then
+    error "Problem setting up the spack environment"
+    return $retval
+fi
+
 spack_load_target_package dunedaq
+retval=$?
+if [[ "$retval" != "0" ]]; then
+    error "Failed to load spack target package. Returning..." 
+    return $retval
+fi
 
 source ${RELEASE_PATH}/${DBT_VENV}/bin/activate
 

--- a/scripts/dbt-setup-release.sh
+++ b/scripts/dbt-setup-release.sh
@@ -55,11 +55,11 @@ EOU
 done
 
 if [[ ! -z "${CUSTOM_BASEPATH}" ]]; then
-    SPACK_RELEASES_DIR="${CUSTOM_BASEPATH}"
+    export SPACK_RELEASES_DIR="${CUSTOM_BASEPATH}"
 elif [ "${NIGHTLY}" = false ]; then
-    SPACK_RELEASES_DIR="${PROD_BASEPATH}"
+    export SPACK_RELEASES_DIR="${PROD_BASEPATH}"
 else
-    SPACK_RELEASES_DIR="${NIGHTLY_BASEPATH}"
+    export SPACK_RELEASES_DIR="${NIGHTLY_BASEPATH}"
 fi
 
 
@@ -77,8 +77,11 @@ if [[ ${#ARGS[@]} -eq 0 ]]; then
     return 11 
 fi
 
-SPACK_RELEASE=${ARGS[0]}
-RELEASE_PATH=$(realpath -m "${SPACK_RELEASES_DIR}/${SPACK_RELEASE}")
+RELEASE_TAG=${ARGS[0]}
+RELEASE_PATH=$(realpath -m "${SPACK_RELEASES_DIR}/${RELEASE_TAG}")
+export SPACK_RELEASE=$( echo $RELEASE_PATH | sed -r 's!.*/([^/]+)/?$!\1!' )
+
+test ! "$SPACK_RELEASE" == "$RELEASE_TAG"  && echo "Release \"$RELEASE_TAG\" requested; interpreting this as release \"$SPACK_RELEASE\""
 
 if [[ ! -d ${RELEASE_PATH} ]]; then 
     error  "Release path '${RELEASE_PATH}' does not exist. Note that you need to pass \"-n\" for a nightly build. Exiting..." 

--- a/scripts/dbt-setup-tools.sh
+++ b/scripts/dbt-setup-tools.sh
@@ -237,8 +237,9 @@ function list_releases() {
 
     local release_path=$1
     pushd $release_path >& /dev/null
-    ls | sort | xargs -i printf " - %s" {}
-    popd >& /dev/null
     echo
+    ls | sort | xargs -i printf " - %s\n" {}
+    echo
+    popd >& /dev/null
 }
 #------------------------------------------------------------------------------


### PR DESCRIPTION
The same problem we saw a few days ago with `dbt-create.py -n last_successful ...` wherein Spack would try (and fail) to load an environment called "last_successful" exists for `dbt-setup-release`. This PR fixes this, as well as:
* If there _is_ a problem, `dbt-setup-release` will no longer continue running, and `DBT_SETUP_RELEASE_SCRIPT_SOURCED` won't get set
* If `dbt-setup-release -l -n` is called, the releases appear one per line now