### PR TITLE
JCF: Issue #194: specify stance on CMake policy 116 so that CMake 3.2…

### DIFF
--- a/bin/dbt-build.py
+++ b/bin/dbt-build.py
@@ -175,7 +175,7 @@ if not os.path.exists("CMakeCache.txt"):
     if args.cmake_msg_lvl:
         cmake_msg_lvl = args.cmake_msg_lvl
 
-    fullcmd="{} -DCMAKE_MESSAGE_LOG_LEVEL={} -DMOO_CMD={} -DDBT_ROOT={} -DDBT_DEBUG={} -DCMAKE_INSTALL_PREFIX={} -G Ninja {}".format(cmake, cmake_msg_lvl, moo_path, os.environ["DBT_ROOT"], debug_build, INSTALLDIR, SRCDIR)
+    fullcmd="{} -DCMAKE_POLICY_DEFAULT_CMP0116=NEW -DCMAKE_MESSAGE_LOG_LEVEL={} -DMOO_CMD={} -DDBT_ROOT={} -DDBT_DEBUG={} -DCMAKE_INSTALL_PREFIX={} -G Ninja {}".format(cmake, cmake_msg_lvl, moo_path, os.environ["DBT_ROOT"], debug_build, INSTALLDIR, SRCDIR)
 
     rich.print(f"Executing '{fullcmd}'")
     retval=pytee.run(fullcmd.split(" ")[0], fullcmd.split(" ")[1:], build_log)


### PR DESCRIPTION
…1.4 doesn't complain

The gory details can be found if you run `cmake --help-policy CMP0116` at the command line in a Spack-based work area, but in a nutshell, `moo_render` calls `add_custom_command` with a `DEPFILE` argument, and CMake changed its policy on relative paths for this argument in 3.20. This is irrelevant since our argument is an absolute path, so this commit basically sets a variable to get the warning to shut up. 