### PR TITLE
Johnfreeman/issue190 update internal checks

### DIFF
--- a/bin/dbt-build
+++ b/bin/dbt-build
@@ -1,18 +1,25 @@
 #!/usr/bin/env python3
 
 import os
-DBT_ROOT=os.environ["DBT_ROOT"]
+import sys
+
+if "DBT_ROOT" in os.environ:
+   DBT_ROOT=os.environ["DBT_ROOT"]
+else:
+    print("Environment variable DBT_ROOT isn't set, which suggests you haven't yet set up the daq-buildtools environment. Exiting...")
+    sys.exit(1)
+
 exec(open(f'{DBT_ROOT}/scripts/dbt_setup_constants.py').read())
 
-import sys
 if sys.prefix == sys.base_prefix:
-    sys.stderr.write("\nYou need your Python virtualenv to be set up for this script to work; have you run dbt-workarea-env yet?")
-    sys.stderr.write("\nSee https://dune-daq-sw.readthedocs.io/en/latest/packages/daq-buildtools/ for details. Exiting...\n\n")
+    sys.stderr.write("\n\033[1;31mYou need your Python virtualenv to be set up for this script to work; have you run \"dbt-workarea-env\" yet?")
+    sys.stderr.write("\nSee https://dune-daq-sw.readthedocs.io/en/latest/packages/daq-buildtools/ for details. Exiting...\n\033[1;0m\n")
     sys.exit(1)
 
 import argparse
 import io
 import multiprocessing
+import pathlib
 import re
 import sh
 import shutil
@@ -25,7 +32,6 @@ sys.path.append(f'{DBT_ROOT}/scripts')
 
 from dbt_setup_tools import error, find_work_area, get_time
 import pytee
-
 
 def get_package_list( build_dir ) :
     return sh.find(r"-L . -mindepth 1 -maxdepth 1 -type d -not -name CMakeFiles  -printf %f\n".split()).split()
@@ -57,7 +63,7 @@ Usage
 
 BASEDIR=find_work_area()
 if not os.path.exists(BASEDIR):
-    error("daq-buildtools work area directory not found. Exiting...")
+    error(f"Work area directory \"{BASEDIR}\" not found. Exiting...")
 
 BUILDDIR=f"{BASEDIR}/build"
 LOGDIR=f"{BASEDIR}/log"
@@ -71,7 +77,6 @@ parser.add_argument("-v", "--cpp-verbose", action="store_true", dest='cpp_verbos
 parser.add_argument("-j", "--jobs", action='store', type=int, dest='n_jobs', help=argparse.SUPPRESS)
 parser.add_argument("--unittest", nargs="?", const="all", help=argparse.SUPPRESS)
 parser.add_argument("--lint", nargs="?", const="all", help=argparse.SUPPRESS)
-parser.add_argument("-i", "--install", action="store_true", help=argparse.SUPPRESS)
 parser.add_argument("--cmake-msg-lvl", dest="cmake_msg_lvl", help=argparse.SUPPRESS)
 parser.add_argument("--cmake-trace", action="store_true", dest="cmake_trace", help=argparse.SUPPRESS)
 parser.add_argument("--cmake-graphviz", action="store_true", dest="cmake_graphviz", help=argparse.SUPPRESS)
@@ -91,9 +96,6 @@ if args.lint:
     if args.lint != "all":
         package_to_lint = args.lint
 
-if args.install:
-    error("Use of -i/--install is deprecated as installation always occurs now; run with \" --help\" to see valid options. Exiting...")
-
 force_clean = False
 if args.yes_to_all:
     force_clean = True
@@ -105,7 +107,12 @@ running this script. Exiting...
     """)
 
 if not os.path.exists(BUILDDIR):
-    error(f"Expected build directory \"{BUILDDIR}\" not found. Exiting...")
+    rich.print(f"[yellow]WARNING: expected build directory \"{BUILDDIR}\" not found. This suggests there may be a problem. Creating \"{BUILDDIR}\"[/yellow]")
+    try:
+        pathlib.Path(BUILDDIR).mkdir(parents=True)
+    except PermissionError:
+        error(f"You don't have permission to create {BUILDDIR} from this directory. Exiting...")
+
 os.chdir(BUILDDIR)
 
 if args.clean_build:
@@ -128,7 +135,7 @@ if args.clean_build:
     else:
         error(f"""
 You requested a clean build, but this script thinks that {os.getcwd()} isn't
-the build directory. Please contact John Freeman at jcfree@fnal.gov and notify him of this message.
+a build directory. Please contact John Freeman at jcfree@fnal.gov and notify him of this message.
         """)
 
 
@@ -154,14 +161,20 @@ cfggentime=None
 if not os.path.exists("CMakeCache.txt"):
     running_config_and_generate = True
 
+    found_cvmfs_ninja = False
     try:
-        re.search(r"^/cvmfs", sh.which("ninja"))
+        res = re.search(r"^/cvmfs", sh.which("ninja"))
+        if res is not None:
+           found_cvmfs_ninja = True
     except:
+        pass
+
+    if not found_cvmfs_ninja:
         error("Ninja seems to be missing. The \"which ninja\" command did not yield an executable in the /cvmfs area. Exiting...")
 
     stringio_obj3 = io.StringIO()
     the_which_cmd = sh.Command("which")  # Needed because of a complex alias, at least on mu2edaq
-    the_which_cmd("moo", _out=stringio_obj3)
+    the_which_cmd("moo", _out=stringio_obj3)  # Will raise helpful exception if moo not found
     moo_path=stringio_obj3.getvalue().strip().split()[-1]
 
     starttime_cfggen_d=get_time("as_date")
@@ -197,7 +210,7 @@ This script ran into a problem running
 from {BUILDDIR} (i.e., CMake's build file config+generate stages).
 Scroll up for details or look at the build log via
 
-less -R {BUILDDIR}
+less -R {build_log}
 
 Exiting...
 
@@ -213,10 +226,16 @@ if args.cmake_graphviz:
 if args.n_jobs:
     nprocs_argument = f"-j {args.n_jobs}"
 else:
-    nprocs = multiprocessing.cpu_count()
-    nprocs_argument = f"-j {nprocs}"
+    nprocs = -999
+    try:
+        nprocs = multiprocessing.cpu_count()
+    except NotImplementedError:
+        error("Unable to determine the number of processors on this system; please supply the \"--jobs <num_processors>\" argument to this script explicitly. Exiting...")
 
     rich.print(f"This script believes you have {nprocs} processors available on this system, and will use as many of them as it can")
+
+    nprocs_argument = f"-j {nprocs}"
+
 
 starttime_build_d=get_time("as_date")
 starttime_build_s=get_time("as_seconds_since_epoch")
@@ -254,12 +273,15 @@ Exiting...
 
 stringio_obj4 = io.StringIO()
 
-num_estimated_warnings = 0
 try:
     sh.wc(sh.grep("warning: ", build_log), "-l", _out=stringio_obj4)
-    num_estimated_warnings=int(stringio_obj4.getvalue().strip())
 except sh.ErrorReturnCode_1:
-    pass
+    num_estimated_warnings = -1
+else:
+   if stringio_obj4.getvalue() is not None:
+      num_estimated_warnings=int(stringio_obj4.getvalue().strip())
+   else:
+      num_estimated_warnings = 0
 
 rich.print("")
 
@@ -296,6 +318,7 @@ for pkg in get_package_list(BUILDDIR):
             filter_f = fs.translate(mp)
             summary_build_info[pkg] = json.loads(filter_f)
     except FileNotFoundError:
+        rich.print(f"[yellow]WARNING: unable to find build info summary file \"{INSTALLDIR}/{pkg}/{pkg}_build_info.json\"[/yellow]")
         summary_build_info[pkg] = "Build info not available"
 
 with open(f"{INSTALLDIR}/build_summary_info.json", 'w') as sbi_f:
@@ -347,7 +370,7 @@ RUNNING UNIT TESTS IN {unittestdir}
                 unittest_relpath = os.path.relpath(unittest_path, BASEDIR)
                 if which(unittest_path, mode=os.X_OK) is not None:
                     pytee.run("echo", "-e Start of unit test suite {}".format(unittest).split(), test_log)
-                    pytee.run(unittest_path, "", test_log)
+                    retval = pytee.run(unittest_path, "", test_log)
                     ## Generate test_log_summary now
                     f_test_log = open(test_log, 'r')
                     test_result = re.findall(r'\*\*\* (No errors detected)', f_test_log.read())
@@ -392,7 +415,9 @@ if args.lint:
         rich.print(f"Package to lint is {pkgname}")
         fullcmd = f"./styleguide/cpplint/dune-cpp-style-check.sh build sourcecode/{pkgname}"
         lint_log = f"{lint_log_dir}/{pkgname}_linting.log"
-        pytee.run(fullcmd.split()[0], fullcmd.split()[1:], lint_log)
+        retval = pytee.run(fullcmd.split()[0], fullcmd.split()[1:], lint_log)
+        if retval != 0:
+           error(f"There was a problem linting package \"{pkgname}\". Exiting...")
 
 rich.print("")
 if cfggentime is not None:
@@ -407,17 +432,21 @@ rich.print(f"CMake's build stage took {buildtime} seconds")
 rich.print(f"Start time: {starttime_build_d}")
 rich.print(f"End time:   {endtime_build_d}")
 
-if num_estimated_warnings > 0:
+if num_estimated_warnings == 0:
+    pass   # Avoiding screen clutter more important than making developers feel good
+elif num_estimated_warnings > 0:
     rich.print("")
     rich.print(f"The build found an estimated {num_estimated_warnings} warnings")
     rich.print("")
+else:
+    rich.print(f"[yellow]WARNING: unable to estimate the number of warnings from the logfile \"{build_log}\"; manual inspection may help.[/yellow]")
 
 testinfo = ""
 if run_tests:
     testinfo=f"""
 Unit test summary can be found in {test_log_summary}.
 Detailed unit test results are saved in the following directory:
-{test_log_dir}.
+{test_log_dir}
 """
 
 lintinfo = ""

--- a/bin/dbt-create
+++ b/bin/dbt-create
@@ -1,14 +1,23 @@
 #!/usr/bin/env python3
+import os
 import sys
 
-if not (sys.version_info[0] == 3 and sys.version_info[1] >= 6):
-    raise Exception("""Python > 3.6.0 is required. On systems with cvmfs, you can obtain Python 3.8.3 by executing the following:
+if not (sys.version_info.major, sys.version_info.minor) > (3, 6):
+    print("""
+Python > 3.6.0 is required. On systems with cvmfs, you can obtain Python 3.8.3 by executing the following:
 
     source `realpath /cvmfs/dunedaq.opensciencegrid.org/spack-externals/spack-installation/share/spack/setup-env.sh`
-    spack load python@3.8.3%gcc@8.2.0""")
+    spack load python@3.8.3%gcc@8.2.0
 
-import os
-DBT_ROOT=os.environ["DBT_ROOT"]
+Exiting...
+""")
+    sys.exit(1)
+
+if "DBT_ROOT" in os.environ:
+   DBT_ROOT=os.environ["DBT_ROOT"]
+else:
+    print("Environment variable DBT_ROOT isn't set, which suggests you haven't yet set up the daq-buildtools environment. Exiting...")
+    sys.exit(2)
 
 exec(open('{}/scripts/dbt_create.py'.format(DBT_ROOT)).read())
 

--- a/env.sh
+++ b/env.sh
@@ -19,7 +19,6 @@ source ${DBT_ROOT}/scripts/dbt-setup-tools.sh
 add_many_paths PATH ${DBT_ROOT}/bin ${DBT_ROOT}/scripts
 export PATH
 
-dbt-setup-build-environment() { error "This command is deprecated; please run \"dbt-workarea-env\" instead" ; }
 dbt-workarea-env() { source ${DBT_ROOT}/scripts/dbt-workarea-env.sh $@; }
 dbt-setup-release() { source ${DBT_ROOT}/scripts/dbt-setup-release.sh $@; }
 

--- a/scripts/dbt-setup-release.sh
+++ b/scripts/dbt-setup-release.sh
@@ -149,13 +149,6 @@ fi
 
 source ${RELEASE_PATH}/${DBT_VENV}/bin/activate
 
-if [[ "$VIRTUAL_ENV" == "" ]]
-then
-    error "You are already in a virtual env. Please deactivate first. Returning..." 
-    spack unload $target_package
-    return 13
-fi
-
 export PYTHONPYCACHEPREFIX=`mktemp -d -t ${SPACK_RELEASE}-XXXX`
 
 export DBT_PACKAGE_SETUP_DONE=1

--- a/scripts/dbt-setup-release.sh
+++ b/scripts/dbt-setup-release.sh
@@ -62,10 +62,15 @@ else
     export SPACK_RELEASES_DIR="${NIGHTLY_BASEPATH}"
 fi
 
-
 ARGS=("$@")
 
 source ${HERE}/dbt-setup-tools.sh
+
+if [[ ! -e $SPACK_RELEASES_DIR ]]; then
+    error "Directory \"$SPACK_RELEASES_DIR\" does not appear to exist; exiting..."
+    return 10
+fi
+
 
 if [[ "${SHOW_RELEASE_LIST}" == true ]]; then
     list_releases $SPACK_RELEASES_DIR
@@ -92,7 +97,7 @@ if [[ -n ${DBT_WORKAREA_ENV_SCRIPT_SOURCED:-} ]]; then
     error "$( cat<<EOF
 
 It appears you're trying to run this script from an environment
-where another development area's been set up.  You'll want to run this
+where a work area's been set up.  You'll want to run this
 from a clean shell. Exiting...     
 
 EOF
@@ -103,9 +108,8 @@ fi
 if [[ -n ${DBT_SETUP_RELEASE_SCRIPT_SOURCED:-} ]]; then
     error "$( cat<<EOF
 
-It appears you're trying to run this script from an environment
-where another running environment been set up.  You'll want to run this
-from a clean shell. Exiting...     
+It appears a release environment was set up prior to you running this script ($RELEASE_TAG).  
+You'll want to run this from a clean shell. Exiting...     
 
 EOF
 )"
@@ -126,11 +130,29 @@ if [[ "$retval" != "0" ]]; then
     return $retval
 fi
 
+if [[ "$VIRTUAL_ENV" != "" ]]; then
+    the_activated_env=$( pip -V  | sed -r 's!\pip [0-9\.]+ from (.*)/lib/python[0-9\.]+/site-packages/pip .*!\1!' )
+    if [[ $the_activated_env != "${DBT_AREA_ROOT}/${DBT_VENV}" ]]; then
+	error "$( cat<<EOF
+
+A python environment outside this work area has already been activated: 
+${the_activated_env}
+If you understand why this is the case and wish to deactivate it, you can
+do so by running "deactivate", then try this script again. Exiting...
+EOF
+)"
+	spack unload $target_package
+	return 7
+    fi
+fi
+
+
 source ${RELEASE_PATH}/${DBT_VENV}/bin/activate
 
 if [[ "$VIRTUAL_ENV" == "" ]]
 then
     error "You are already in a virtual env. Please deactivate first. Returning..." 
+    spack unload $target_package
     return 13
 fi
 

--- a/scripts/dbt-workarea-env.sh
+++ b/scripts/dbt-workarea-env.sh
@@ -139,13 +139,6 @@ EOF
     fi
 
     source ${DBT_AREA_ROOT}/${DBT_VENV}/bin/activate
-
-    if [[ "$VIRTUAL_ENV" == "" ]]
-    then
-	error "You are already in a virtual env. Please deactivate first. Returning..." 
-	spack unload $target_package
-	return 11
-    fi
      
     export DBT_PACKAGE_SETUP_DONE=1
 


### PR DESCRIPTION
Mostly added error checks, but took a couple away which were obsolete or a subset of the new error checks. Focus was on the scripts which users typically interact with: `dbt-create`, `dbt-build`, `dbt-workarea-env`, `dbt-setup-release`. A non-comprehensive summary of what was done includes:

* Turning the lack of a `./build` directory into a warning rather than an error, and then creating it
* Adding color codes to error messages and warnings which don't use `rich`
* Removal of the "`--install` is obsolete" warning since that goes back many, many months by now
* More checks for potentially-missing directories (e.g., in `dbt-setup-release.sh`)
* More checks for potentially-unset environment variables
* In `dbt-create`, replaced the "your desired work area directory has stuff in it" error with a simpler "your desired work area already exists" error

Along with looking at the code changes themselves, a good way to test these changes is to see if you can get our scripts to choke in such a way that it's not obvious to the user why they're choking (i.e., the sorts of problems caused by bad inputs or environments that cause Slack messages and emails to get sent our way)