### PR TITLE
JCF: Issue #227: have the Python environment cloned by default, and o…

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -59,21 +59,22 @@ It will set up both the external packages and DAQ packages, as well as activate 
 
 Find a directory in which you want your work area to be a subdirectory (home directories are a popular choice) and `cd` into that directory. Then think of a good name for the work area (give it any name, but we'll refer to it as "MyTopDir" on this wiki). If you want to build against the nightly release (i.e., the official DUNE DAQ package installation which updates every night), run:
 ```sh
-dbt-create [-c/--clone-pyvenv] -n <nightly release> <name of work area subdirectory> # E.g., N22-04-18 or last_successful
+dbt-create -n <nightly release> <name of work area subdirectory> # E.g., N22-04-18 or last_successful
 cd <name of work area subdirectory>
 ```
 
 If you want to build against a candidate release (which is built and deployed during the beta testing period of a release cycle), run:
 ```sh
-dbt-create [-c/--clone-pyvenv] -b candidate <candidate release> <name of work area subdirectory> # E.g., rc-dunedaq-v3.0.0-1 as of May-23-2022.
+dbt-create -b candidate <candidate release> <name of work area subdirectory> # E.g., rc-dunedaq-v3.0.0-1 as of May-23-2022.
 cd <name of work area subdirectory>
 ```
+The second of the two commands above is important: remember to `cd` into the subdirectory you just created after `dbt-create` finishes running. 
 
 To see all available nightly releases, run `dbt-create -l -n` or `dbt-create -l -b nightly`. To see all available candidate releases, run `dbt-create -l -b candidate`. Less common but also possible is to build your repos not against a nightly release but against a frozen release; the commands you pass to `dbt-create` are the same, but with the `-n` or `-b <option>` dropped. 
 
-The option `-c/--clone-pyvenv` for `dbt-create` is optional. If used, the python virtual environment created in the work area will be a clone of an existing one from the release directory. This avoids the compilation/installation of python modules using the `pyvenv_requirements.txt` in the release directory, and speeds up the work-area creation significantly. The first time running `dbt-create` with this option on a node may take a longer time since cvmfs needs to fetch these files into local cache first.
+Another option is for `dbt-create` is `-i/--install-pyvenv`. Without this option, the python virtual environment created in the work area will be a clone of an existing one from the release directory. However, with this option, there will be compilation/installation of python modules using the `pyvenv_requirements.txt` in the release directory. This is typically slower than cloning, but not always. 
 
-The second of the two commands above is important: remember to `cd` into the subdirectory you just created after `dbt-create` finishes running. 
+Note that the first time running `dbt-create` on a node may take a longer time since cvmfs needs to fetch files into local cache first.
 
 The structure of your work area will look like the following:
 ```txt

--- a/scripts/dbt-clone-pyvenv.sh
+++ b/scripts/dbt-clone-pyvenv.sh
@@ -40,13 +40,17 @@ spack_setup_env
 spack_load_target_package systems  # Error checking occurs inside function
 
 ###
-# Check existance/create the default virtual_env
+# Check existence/create the default virtual_env
 ###
+echo
 if [ -f "${DBT_AREA_ROOT}/${DBT_VENV}/pyvenv.cfg" ]; then
     echo -e "INFO [`eval $timenow`]: virtual_env ${DBT_VENV} already exists."
     cat "${DBT_AREA_ROOT}/${DBT_VENV}/pyvenv.cfg"
 else
-    echo -e "INFO [`eval $timenow`]: creating virtual_env ${DBT_VENV} by cloning ${PARENT_VENV}. "
+    echo -e "INFO [`eval $timenow`]: creating virtual_env ${DBT_VENV} by cloning"
+    echo -e "${PARENT_VENV}. "
+    echo -e "Depending on a variety of factors this can take from several seconds to several minutes..."
+
     ${HERE}/../bin/clonevirtualenv.py ${PARENT_VENV} ${DBT_AREA_ROOT}/${DBT_VENV}
 
     test $? -eq 0 || error "Problem creating virtual_env ${DBT_VENV}. Exiting..." 


### PR DESCRIPTION
…nly installed if the -i option is passed. Also provide a -p option to override the default Python requirements file.

Running `dbt-create -h` will outline the changes made here, with one exception: If you pass `-i` or `--install-pyvenv`, you also have the option to pass `-p` or `--pyvenv-requirements` followed by the fully qualified path of a Python requirements file. If you don't pass `-p` it'll use the usual default Python requirements file, i.e., the `pyvenv_requirements.txt` in the release's directory. 