### PR TITLE
Thea/venv setup

### DIFF
--- a/scripts/dbt-create-pyvenv.sh
+++ b/scripts/dbt-create-pyvenv.sh
@@ -47,7 +47,7 @@ if [ -f "${DBT_AREA_ROOT}/${DBT_VENV}/pyvenv.cfg" ]; then
     cat "${DBT_AREA_ROOT}/${DBT_VENV}/pyvenv.cfg"
 else
     echo -e "INFO [`eval $timenow`]: creating virtual_env ${DBT_VENV}. "
-    python -m venv -p ${DBT_VENV_PROMPT} ${DBT_AREA_ROOT}/${DBT_VENV}
+    python -m venv --prompt ${DBT_VENV_PROMPT} ${DBT_AREA_ROOT}/${DBT_VENV}
 
     test $? -eq 0 || error "Problem creating virtual_env ${DBT_VENV}. Exiting..." 
 fi

--- a/scripts/dbt-create-pyvenv.sh
+++ b/scripts/dbt-create-pyvenv.sh
@@ -47,7 +47,7 @@ if [ -f "${DBT_AREA_ROOT}/${DBT_VENV}/pyvenv.cfg" ]; then
     cat "${DBT_AREA_ROOT}/${DBT_VENV}/pyvenv.cfg"
 else
     echo -e "INFO [`eval $timenow`]: creating virtual_env ${DBT_VENV}. "
-    python -m venv ${DBT_AREA_ROOT}/${DBT_VENV}
+    python -m venv -p ${DBT_VENV_PROMPT} ${DBT_AREA_ROOT}/${DBT_VENV}
 
     test $? -eq 0 || error "Problem creating virtual_env ${DBT_VENV}. Exiting..." 
 fi

--- a/scripts/dbt-setup-constants.sh
+++ b/scripts/dbt-setup-constants.sh
@@ -1,6 +1,8 @@
-DBT_VENV="dbt-pyvenv"
+DBT_VENV=".venv"
+DBT_VENV_PROMPT="dbt"
 DBT_AREA_FILE="dbt-workarea-constants.sh"
 
 PROD_BASEPATH="/cvmfs/dunedaq.opensciencegrid.org/spack/releases"
 NIGHTLY_BASEPATH="/cvmfs/dunedaq-development.opensciencegrid.org/nightly"
 CANDIDATE_RELEASE_BASEPATH="/cvmfs/dunedaq-development.opensciencegrid.org/candidates"
+

--- a/scripts/dbt-setup-release.sh
+++ b/scripts/dbt-setup-release.sh
@@ -166,6 +166,7 @@ fi
 
 
 source ${RELEASE_PATH}/${DBT_VENV}/bin/activate
+export PYTHONPATH=$(python -c "import sysconfig; print(sysconfig.get_path('platlib'))"):$PYTHONPATH
 
 export PYTHONPYCACHEPREFIX=`mktemp -d -t ${SPACK_RELEASE}-XXXX`
 

--- a/scripts/dbt-workarea-env.sh
+++ b/scripts/dbt-workarea-env.sh
@@ -148,6 +148,7 @@ EOF
     fi
 
     source ${DBT_AREA_ROOT}/${DBT_VENV}/bin/activate
+    export PYTHONPATH=$(python -c "import sysconfig; print(sysconfig.get_path('platlib'))"):$PYTHONPATH
      
     export DBT_PACKAGE_SETUP_DONE=1
 

--- a/scripts/dbt_create.py
+++ b/scripts/dbt_create.py
@@ -137,7 +137,14 @@ for dbtfile in [f"{DBT_ROOT}/configs/CMakeLists.txt", \
                 ]:
     copy(dbtfile, SRCDIR)
 
-os.symlink(f"{DBT_ROOT}/env.sh", f"{TARGETDIR}/dbt-env.sh")
+# os.symlink(f"{DBT_ROOT}/env.sh", f"{TARGETDIR}/dbt-env.sh")
+env_script_content = f'''
+source {DBT_ROOT}/env.sh
+dbt-workarea-env
+'''
+
+with open(f'{TARGETDIR}/env.sh', "w") as outf:
+    outf.write(env_script_content)
 
 # Set these so the dbt-clone-pyvenv.sh and dbt-create-pyvenv.sh scripts get info they need
 os.environ["SPACK_RELEASE"] = f"{RELEASE}"


### PR DESCRIPTION
This PR contains three updates:


1. change `dbt-pyvenv` prompt to `dbt`;
2. doing `dbt-workarea-env` inside `dbt-env.sh` so developers do not need to run that separately when getting back to a workarea;
3. ensure `PYTHONPATH` includes the venv's site-packages directory so the modules in local venv take precedence over spack installed python modules.