### PR TITLE
support test_release in production repo

### DIFF
--- a/scripts/dbt-setup-constants.sh
+++ b/scripts/dbt-setup-constants.sh
@@ -5,4 +5,5 @@ DBT_AREA_FILE="dbt-workarea-constants.sh"
 PROD_BASEPATH="/cvmfs/dunedaq.opensciencegrid.org/spack/releases"
 NIGHTLY_BASEPATH="/cvmfs/dunedaq-development.opensciencegrid.org/nightly"
 CANDIDATE_RELEASE_BASEPATH="/cvmfs/dunedaq-development.opensciencegrid.org/candidates"
+TEST_RELEASE_BASEPATH="/cvmfs/dunedaq.opensciencegrid.org/test/spack/releases"
 

--- a/scripts/dbt-setup-release.sh
+++ b/scripts/dbt-setup-release.sh
@@ -37,17 +37,17 @@ Usage
 
 To setup a new running environment for a DAQ release:
       
-    ${scriptname} [-r/--release-path <path to release area>] [-n/--nightly] [-b/--base-release <frozen, nightly, candidate>] <dunedaq-release>
+    ${scriptname} [-r/--release-path <path to release area>] [-n/--nightly] [-b/--base-release <frozen, nightly, candidate, test>] <dunedaq-release>
 
 To list the available DUNE DAQ releases:
 
-    ${scriptname} -l/--list [-n/--nightly] [-b/--base-release <frozen, nightly, candidate>] [-r/--release-path <path to release area>]
+    ${scriptname} -l/--list [-n/--nightly] [-b/--base-release <frozen, nightly, candidate, test>] [-r/--release-path <path to release area>]
 
 Arguments and options:
 
     dunedaq-release: is the name of the release the running environment will be based on (e.g. dunedaq-v2.0.0)
     -n/--nightly: switch to nightly releases, shortcut for "-b/--base-release nightly"
-    -b/--base-release: base release type, choosing from ['frozen', 'nighlty', 'candidate'], default is 'frozen'.
+    -b/--base-release: base release type, choosing from ['frozen', 'nighlty', 'candidate', 'test'], default is 'frozen'.
     -l/--list: show the list of available releases
     -r/--release-path: is the path to the release archive (defaults to either $PROD_BASEPATH (frozen) or $NIGHTLY_BASEPATH (nightly))
 
@@ -73,8 +73,10 @@ else
         export SPACK_RELEASES_DIR="${NIGHTLY_BASEPATH}"
     elif [ "${BASETYPE}" = 'candidate' ]; then
         export SPACK_RELEASES_DIR="${CANDIDATE_RELEASE_BASEPATH}"
+    elif [ "${BASETYPE}" = 'test' ]; then
+        export SPACK_RELEASES_DIR="${TEST_RELEASE_BASEPATH}"
     else
-        error "Wrong option for -b/--base-release, please choose from [frozen, nightly, candidate]."
+        error "Wrong option for -b/--base-release, please choose from [frozen, nightly, candidate, test]."
     fi
 fi
 

--- a/scripts/dbt_create.py
+++ b/scripts/dbt_create.py
@@ -28,21 +28,22 @@ To create a new DUNE DAQ development area:
 
 To list the available DUNE DAQ releases:
 
-    {os.path.basename(__file__)} [-n/--nightly] [-b/--base-release <base release type>] [-r/--release-path <path to release area>] -l/--list 
+    {os.path.basename(__file__)} [-n/--nightly] [-b/--base-release <base release type>] [-r/--release-path <path to release area>] -l/--list
 
 Arguments and options:
 
     dunedaq release: the release the new work area will be based on (e.g. dunedaq-v2.8.0, N22-09-29, etc.)
-    target directory: the name of the work area dbt-create will set up for you  
+    target directory: the name of the work area dbt-create will set up for you
     -b/--base-release: base release type, can be one of [frozen, nightly, candidate]. Default is frozen.
     -n/--nightly: switch from frozen to nightly releases, shortcut for \"-b nightly\"
-    -l/--list: show the list of available releases 
-    -r/--release-path: is the path to the release archive (defaults to 
+    -l/--list: show the list of available releases
+    -r/--release-path: is the path to the release archive (defaults to
                        {PROD_BASEPATH} (frozen)
                        {NIGHTLY_BASEPATH} (nightly)
-                       {CANDIDATE_RELEASE_BASEPATH} (candidate))
-    -i/--install-pyvenv: rather than cloning the python virtual environment, 
-                         pip install it off of the pyvenv_requirements.txt 
+                       {CANDIDATE_RELEASE_BASEPATH} (candidate)
+                       {TEST_RELEASE_BASEPATH} (test))
+    -i/--install-pyvenv: rather than cloning the python virtual environment,
+                         pip install it off of the pyvenv_requirements.txt
                          file in the release's directory on cvmfs
 
 See https://dune-daq-sw.readthedocs.io/en/latest/packages/daq-buildtools for more
@@ -52,7 +53,7 @@ See https://dune-daq-sw.readthedocs.io/en/latest/packages/daq-buildtools for mor
 
 parser = argparse.ArgumentParser(usage=usage_blurb)
 parser.add_argument("-n", "--nightly", action="store_true", help=argparse.SUPPRESS)
-parser.add_argument("-b", "--base-release", choices=['frozen', 'nightly', 'candidate'], default='frozen', help=argparse.SUPPRESS)
+parser.add_argument("-b", "--base-release", choices=['frozen', 'nightly', 'candidate', 'test'], default='frozen', help=argparse.SUPPRESS)
 parser.add_argument("-r", "--release-path", action='store', dest='release_path', help=argparse.SUPPRESS)
 parser.add_argument("-l", "--list", action="store_true", dest='_list', help=argparse.SUPPRESS)
 parser.add_argument("-i", "--install-pyvenv", action="store_true", dest='install_pyvenv', help=argparse.SUPPRESS)
@@ -79,6 +80,8 @@ else:
         RELEASE_BASEPATH=NIGHTLY_BASEPATH
     if args.base_release == 'candidate':
         RELEASE_BASEPATH=CANDIDATE_RELEASE_BASEPATH
+    if args.base_release == 'test':
+        RELEASE_BASEPATH=TEST_RELEASE_BASEPATH
 
 if args._list:
     list_releases(RELEASE_BASEPATH)
@@ -169,7 +172,7 @@ else:
     else:
         if not os.path.exists(args.pyvenv_requirements):
             error(f"""
-Requested Python requirements file \"{args.pyvenv_requirements}\" not found. 
+Requested Python requirements file \"{args.pyvenv_requirements}\" not found.
 Please note you need to provide its absolute path. Exiting...
 """)
         cmd = f"{DBT_ROOT}/scripts/dbt-create-pyvenv.sh {args.pyvenv_requirements} 2>&1"

--- a/scripts/dbt_setup_constants.py
+++ b/scripts/dbt_setup_constants.py
@@ -4,5 +4,5 @@ DBT_AREA_FILE="dbt-workarea-constants.sh"
 PROD_BASEPATH="/cvmfs/dunedaq.opensciencegrid.org/spack/releases"
 NIGHTLY_BASEPATH="/cvmfs/dunedaq-development.opensciencegrid.org/nightly"
 CANDIDATE_RELEASE_BASEPATH="/cvmfs/dunedaq-development.opensciencegrid.org/candidates"
-
+TEST_RELEASE_BASEPATH="/cvmfs/dunedaq.opensciencegrid.org/test"
 

--- a/scripts/dbt_setup_constants.py
+++ b/scripts/dbt_setup_constants.py
@@ -1,4 +1,4 @@
-DBT_VENV="dbt-pyvenv"
+DBT_VENV=".venv"
 DBT_AREA_FILE="dbt-workarea-constants.sh"
 
 PROD_BASEPATH="/cvmfs/dunedaq.opensciencegrid.org/spack/releases"

--- a/scripts/dbt_setup_constants.py
+++ b/scripts/dbt_setup_constants.py
@@ -4,5 +4,5 @@ DBT_AREA_FILE="dbt-workarea-constants.sh"
 PROD_BASEPATH="/cvmfs/dunedaq.opensciencegrid.org/spack/releases"
 NIGHTLY_BASEPATH="/cvmfs/dunedaq-development.opensciencegrid.org/nightly"
 CANDIDATE_RELEASE_BASEPATH="/cvmfs/dunedaq-development.opensciencegrid.org/candidates"
-TEST_RELEASE_BASEPATH="/cvmfs/dunedaq.opensciencegrid.org/test"
+TEST_RELEASE_BASEPATH="/cvmfs/dunedaq.opensciencegrid.org/test/spack/releases"
 


### PR DESCRIPTION
This is to support test releases (fake releases) put under `/cvmfs/dunedaq.opensciencegrid.org` repo.

These releases will follow frozen releases patten, but instead of being under `/cvmfs/dunedaq.opensciencegrid.org/spack/releases`, they will be under `/cvmfs/dunedaq.opensciencegrid.org/test/spack/releases`. Note the first-level `test` subdirectory in the cvmfs repo.

