### PR TITLE
Support of using venv from cvmfs and install a writable local spack instance when calling `dbt-create`

### DIFF
--- a/scripts/dbt-create-spack.sh
+++ b/scripts/dbt-create-spack.sh
@@ -1,0 +1,50 @@
+#!/bin/env bash
+
+#------------------------------------------------------------------------------
+HERE=$(cd $(dirname $(readlink -f ${BASH_SOURCE})) && pwd)
+
+source ${HERE}/dbt-setup-tools.sh
+
+if (( $# > 1 )); then
+    error "Usage: $( basename $0 )"
+    exit 1
+fi
+
+PYENV_REQS=$1
+
+#------------------------------------------------------------------------------
+timenow="date \"+%D %T\""
+
+###
+# Check if inside a virtualenv already
+###
+if [[ -z ${LOCAL_SPACK_DIR} ]]
+then
+  error "Environment variable LOCAL_SPACK_DIR needs to be set for this script to work. Exiting..."
+fi
+
+DBT_AREA_ROOT=$(find_work_area)
+if [[ -z ${DBT_AREA_ROOT} ]]; then
+    error "Expected work area directory not found via call to find_work_area. Exiting..."
+fi
+
+if [[ -z $SPACK_RELEASE ]]; then
+    error "Environment variable SPACK_RELEASE needs to be set for this script to work. Exiting..."
+fi
+
+if [[ -z $SPACK_RELEASES_DIR ]]; then
+    error "Environment variable SPACK_RELEASES_DIR needs to be set for this script to work. Exiting..."
+fi
+
+
+###
+# Check existance/create the default virtual_env
+###
+if [ -d "${LOCAL_SPACK_DIR}" ]; then
+    error "Directory ${LOCAL_SPACK_DIR} already exists. Exiting..."
+else
+    echo -e "INFO [`eval $timenow`]: creating a local spack instance under ${LOCAL_SPACK_DIR}. "
+    existing_spack_dir=`realpath $SPACK_RELEASES_DIR/$SPACK_RELEASE/default/spack-installation`
+    stack_new_spack $existing_spack_dir $LOCAL_SPACK_DIR
+fi
+

--- a/scripts/dbt-workarea-env.sh
+++ b/scripts/dbt-workarea-env.sh
@@ -132,10 +132,22 @@ if [[ -z "${DBT_PACKAGE_SETUP_DONE}" ]]; then
     [[ $(type -P "trace_functions.sh") ]] && source `which trace_functions.sh`
 
     # Assumption is you've already spack loaded python, etc...
+    local_venv_dir=${DBT_AREA_ROOT}/${DBT_VENV}
+    release_venv_dir=`realpath ${SPACK_RELEASES_DIR}/$SPACK_RELEASE/${DBT_VENV}`
+    venv_path=""
+    if [ -d $local_venv_dir ]; then
+	echo
+	echo "Found venv in the current workarea, activating it now... "
+	venv_path=$local_venv_dir
+    else
+	echo
+	echo "No local venv found, activating venv from the release directory on cvmfs..."
+	venv_path=$release_venv_dir
+    fi
 
     if [[ "$VIRTUAL_ENV" != "" ]]; then
 	the_activated_env=$( pip -V  | sed -r 's!\pip [0-9\.]+ from (.*)/lib/python[0-9\.]+/site-packages/pip .*!\1!' )
-	if [[ $the_activated_env != "${DBT_AREA_ROOT}/${DBT_VENV}" ]]; then
+	if [[ $the_activated_env != "$venv_path" ]]; then
 	    error "$( cat<<EOF
 
 A python environment outside this work area has already been activated: 
@@ -149,7 +161,7 @@ EOF
 	fi
     fi
 
-    source ${DBT_AREA_ROOT}/${DBT_VENV}/bin/activate
+    source ${venv_path}/bin/activate
     export PYTHONPATH=$(python -c "import sysconfig; print(sysconfig.get_path('platlib'))"):$PYTHONPATH
      
     export DBT_PACKAGE_SETUP_DONE=1
@@ -199,6 +211,3 @@ export DBT_WORKAREA_ENV_SCRIPT_SOURCED=1
 
 echo -e "${COL_GREEN}This script has been sourced successfully${COL_RESET}"
 echo
-
-
-

--- a/scripts/dbt_create.py
+++ b/scripts/dbt_create.py
@@ -12,7 +12,7 @@ from time import sleep
 
 sys.path.append(f'{DBT_ROOT}/scripts')
 
-from dbt_setup_tools import error, get_time, list_releases
+from dbt_setup_tools import error, get_time, list_releases, run_command
 
 PY_PKGLIST="pyvenv_requirements.txt"
 DAQ_BUILDORDER_PKGLIST="dbt-build-order.cmake"
@@ -176,18 +176,7 @@ with open(f'{TARGETDIR}/dbt-workarea-constants.sh', "w") as outf:
 
 if args.install_spack:
     # create local spack instance here.
-    cmd = f"{DBT_ROOT}/scripts/dbt-create-spack.sh 2>&1"
-    res = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE,
-                        stderr=subprocess.PIPE)
-    while True:
-        output = res.stdout.readline()
-        if res.poll() is not None:
-            break
-        if output:
-            print(output.rstrip().decode("utf-8"))
-        res.poll()
-    if res.returncode != 0:
-        error(f"There was a problem running \"{cmd}\" (return value {res.returncode}); exiting...")
+    run_command(f"{DBT_ROOT}/scripts/dbt-create-spack.sh 2>&1")
 
 if args.install_pyvenv:
     print("Setting up the Python subsystem.")
@@ -209,19 +198,7 @@ else:
     print("Skipping the creation of python vitual environment in the workarea.")
     print(f"Default python venv under {RELEASE_PATH}/.venv will be used.")
 
-res = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE,
-                        stderr=subprocess.PIPE)
-
-while True:
-    output = res.stdout.readline()
-    if res.poll() is not None:
-        break
-    if output:
-        print(output.rstrip().decode("utf-8"))
-    res.poll()
-
-if res.returncode != 0:
-    error(f"There was a problem running \"{cmd}\" (return value {res.returncode}); exiting...")
+run_command(cmd)
 
 endtime_d=get_time("as_date")
 endtime_s=get_time("as_seconds_since_epoch")

--- a/scripts/dbt_setup_tools.py
+++ b/scripts/dbt_setup_tools.py
@@ -54,3 +54,18 @@ def get_time(kind):
         assert False, "Unknown argument passed to get_time"
 
     return timenow
+
+def run_command(cmd):
+
+    res = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE,
+                        stderr=subprocess.PIPE)
+
+    while True:
+        output = res.stdout.readline()
+        if output:
+            print(output.rstrip().decode("utf-8"))
+        if res.poll() is not None:
+            break
+
+    if res.returncode != 0:
+        error(f"There was a problem running \"{cmd}\" (return value {res.returncode}); exiting...")


### PR DESCRIPTION
## This PR contains two features:

### support the use of python venv from cvmfs, and avoid the time-consuming cloning/installing a venv into a work area;

The first feature allows developers to skip the creation of python venv (either via clone or fresh install) inside a workarea when using `dbt-create`.

Unless `-i/--install-pyvenv` or `-c/--clone-pyvenv` is used with `dbt-create`, the workarea will not contain a pre-installed python venv.

`dbt-workarea-env` will check the existence of `$DBT_WORKAREA_ROOT/$DBT_VENV`, if not found, it will activate the python venv in the release directory on cvmfs.

### support the installation of a writable spack instance into a work area, so developers can install their own spack packages.

Use option `-s/--spack` when calling `dbt-create`.

This optionw will create `.spack` under the workarea, and add `LOCAL_SPACK_DIR` env to the `dbt-workarea-constants.sh`.

The local `.spack` is a clone of the spack instance from the release directory on cvmfs with the following modifications:
1. the packages installed in the release are skipped;
2. a `spack-repo` subdir is created, and added to the `repos.yaml` in the local `.spack`. In case one need to modify a package's recipe file, they should copy over the existing recipe file into `.spack/spack-repo/packages/<pkg_name>`, and modify it there;
3. the spack instance from the release is added as an upstream spack instance, together with all existing upstream instances used by the release.

When calling `dbt-workarea-env`, it will check if `LOCAL_SPACK_DIR` is set, if so, load the spack setup script from there.