### PR TITLE
Added three handy functions

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # DUNE DAQ Buildtools
 
-_This document was last edited Aug-10-2023_
+_This document was last edited Sep-7-2023_
 
 `daq-buildtools` is the toolset to simplify the development of DUNE DAQ packages. It provides environment and building utilities for the DAQ Suite.
 
@@ -193,7 +193,17 @@ In the listrev instructions you'll be running a program called `nanorc` to run t
 
 A couple of things need to be kept in mind when you're building code in a work area. The first is that when you call `dbt-build`, it will build your repos against a specific release of the DUNE DAQ software stack - namely, the release you (or someone else) provided to `dbt-create` when the work area was first created. Another is that the layout and behavior of a work area is a function of the version of daq-buildtools which was used to create it. As a work area ages it becomes increasingly likely that a problem will occur when you try to build a repo in it; this is natural and unavoidable. 
 
-As such, it's important to know the assumptions a work area makes when you use it to build code. In the base of your work area is a file called `dbt-workarea-constants.sh`, which will look something like the following:
+As such, it's important to know the assumptions a work area makes when you use it to build code. This section covers ways to learn details about your work area and its contents.
+
+### Convenience scripts
+
+* `dbt-release-info`: will provide the release type the work area is based on (far detector vs. near detector), as well as the name of the full release and the base release 
+* `dbt-pkg-info <pkgname>`: will provide the version/branch of the package referred to by `<pkgname>`, as well as the corresponding git commit hash of its code, whether the package is built in the local work area or is on cvmfs
+* `dbt-src-status`: will tell you the branch each of the repos in your work area is on, as well as whether the code on the branch has been edited (indicated by an `*`) 
+
+### `dbt-workarea-constants.sh`
+
+In the base of your work area is a file called `dbt-workarea-constants.sh`, which will look something like the following:
 ```
 export SPACK_RELEASE="fddaq-v4.1.0"
 export SPACK_RELEASES_DIR="/cvmfs/dunedaq.opensciencegrid.org/spack/releases"
@@ -205,6 +215,8 @@ This file is sourced whenever you run `dbt-workarea-env`, and it tells both the 
 * `$SPACK_RELEASES_DIR`: The base of the directory containing the DUNE DAQ software installations. 
 * `DBT_ROOT_WHEN_CREATED`: The directory containing the `env.sh` file which was sourced before this work area was first created
 * `LOCAL_SPACK_DIR`: If the `-s/--spack` was passed to `dbt-create` when the work area was built, this points to where the local Spack area is located
+
+### Useful Spack commands
 
 There are also useful Spack commands which can be executed to learn about the versions of the individual packages you're working with, once you've run `dbt-workarea-env` or `dbt-setup-release`. An [excellent Spack tutorial](https://spack-tutorial.readthedocs.io/en/latest/tutorial_basics.html) inside the official Spack documentation is worth a look, but a few Spack commands can be used right away to learn more about your environment. They're presented both for the case of you having set up a nightly release and a frozen release:
 * `spack find --loaded -N | grep dunedaq-vX.Y.Z` or `spack find --loaded -N | grep NB` will tell you all the DUNE DAQ packages shared by both far- and near detector software which have been loaded by `dbt-workarea-env` or `dbt-setup-release`

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,84 +1,85 @@
-
-
-_JCF, Nov-11-2022: These instructions are for *developers* of daq-buildtools, not *users*. Most likely you want to go to the official daq-buildtools instructions [here](https://dune-daq-sw.readthedocs.io/en/latest/packages/daq-buildtools/)._
-
-
 # DUNE DAQ Buildtools
+
+_This document was last edited Aug-10-2023_
 
 `daq-buildtools` is the toolset to simplify the development of DUNE DAQ packages. It provides environment and building utilities for the DAQ Suite.
 
 ## System requirements
 
-To get set up, you'll need access to the cvmfs Spack area
-`/cvmfs/dunedaq-development.opensciencegrid.org/spack-nightly` as is
-the case, e.g., on the lxplus machines at CERN. If you've been doing
-your own Spack work on the system in question, you may also want to
-back up (rename) your existing `~/.spack` directory to give Spack a
-clean slate to start from in these instructions.
-
-You'll also want `python` to be version 3; to find out whether this is the case, run `python --version`. If it isn't, then you can switch over to Python 3 with the following simple commands:
-```
-source `realpath /cvmfs/dunedaq.opensciencegrid.org/spack-externals/spack-installation/share/spack/setup-env.sh`
-spack load python@3.8.3%gcc@8.2.0
-```
+To get set up, you'll need access to the cvmfs areas `/cvmfs/dunedaq.opensciencegrid.org` and `/cvmfs/dunedaq-development.opensciencegrid.org`. This is the case, e.g., on the np04 cluster at CERN. If you've been doing your own Spack work on the
+system in question, you may also want to back up (rename) your
+existing `~/.spack` directory to give Spack a clean slate to start
+from in these instructions.
 
 <a name="Setup_of_daq-buildtools"></a>
 ## Setup of `daq-buildtools`
 
-In a directory which doesn't contain a daq-buildtools repository, simply do:
-
+Simply do:
 ```
 source /cvmfs/dunedaq.opensciencegrid.org/setup_dunedaq.sh
-setup_dbt latest-spack
+setup_dbt fddaq-v4.1.1  
 ```
-
-Then you'll see something like:
+Here `fddaq-v4.1.1` is an alias for `v7.2.1`; this is the latest daq-buildtools version as of Aug-10-2023.
+After running these two commands, then you'll see something like:
 ```
-Added /tmp/daq-buildtools/bin -> PATH
-Added /tmp/daq-buildtools/scripts -> PATH
+Added /cvmfs/dunedaq.opensciencegrid.org/tools/dbt/v7.2.1/bin -> PATH
+Added /cvmfs/dunedaq.opensciencegrid.org/tools/dbt/v7.2.1/scripts -> PATH
 DBT setuptools loaded
 ```
 If you type `dbt-` followed by the `<tab>` key you'll see a listing of available commands, which include `dbt-create`, `dbt-build`, `dbt-setup-release` and `dbt-workarea-env`. These are all described in the following sections. 
 
-Each time that you want to work with a DUNE DAQ work area in a fresh Linux shell, you'll need to set up daq-buildtools, either by repeating the method above, or by `cd`'ing into your work area and sourcing the link file named `dbt-env.sh`. Work areas are described momentarily. 
+Each time that you log into a fresh Linux shell and want to either (1) set up an existing cvmfs-based DUNE DAQ software release or (2) develop code within a pre-existing DUNE DAQ work area, you'll need to set up daq-buildtools. These two cases are described in detail momentarily. For (1) you'd want to repeat the method above to set up daq-buildtools. For (2) it's easier instead to `cd` into the work area and source the file named `env.sh`. 
 
 <a name="Running_a_release_from_cvmfs"></a>
 ## Running a release from cvmfs
 
-Running a release from cvmfs without creating a work area can be done if you simply run the following:
+If you only want access to a DUNE DAQ software release (its executables, etc.) without actually developing DUNE DAQ software itself, you'll want to run a release from cvmfs. Please note that in general, frozen releases (especially patch frozen releases) are intended for this scenario, and _not_ for development. After setting up daq-buildtools, you can simply run the following command if you wish to use a frozen release:
 
 ```sh
-dbt-setup-release dunedaq-v2.11.0
+dbt-setup-release <release> # fddaq-v4.1.1 the latest frozen release as of Aug-10-2023
+```
+As of July 2023, the DUNE DAQ software stack has been split into far detector and near detector-specific parts. Starting with the `v4.1.0` release of the stack, do _not_ use the traditional convention of `dunedaq-vX.Y.Z` as the frozen release label, but instead, `fddaq-vX.Y.Z` and `nddaq-vX.Y.Z`. Note that for `v4.1.0` and `v4.1.1` we only have a far detector-specific stack. 
+
+Instead of a frozen release you can also set up nightly releases or candidate releases using the same arguments as are described later for `dbt-create`; e.g. if you want to set up candidate release `fd-v4.1.0-c5` you can do:
+```
+dbt-setup-release -b candidate fd-v4.1.0-c5
 ```
 
-It will set up both the external packages and DAQ packages, as well as activate the python virtual environment. Note that the python virtual environment activated here is read-only. You'd want to run `dbt-setup-release` only if you weren't developing DUNE DAQ software, the topic covered for the remainder of this document. However, if you don't want a frozen set of versioned packages - which you wouldn't, if you were developing code - please continue reading.
-
+`dbt-setup-release` will set up both the external packages and DAQ packages, as well as activate the Python virtual environment. Note that the Python virtual environment activated here is read-only. 
 
 <a name="Creating_a_work_area"></a>
 ## Creating a work area
 
-Find a directory in which you want your work area to be a subdirectory (home directories are a popular choice) and `cd` into that directory. Then think of a good name for the work area (give it any name, but we'll refer to it as "MyTopDir" on this wiki). If you want to build against the nightly release (i.e., the official DUNE DAQ package installation which updates every night), run:
-```sh
-dbt-create -n <nightly release> <name of work area subdirectory> # E.g., N22-04-18 or last_successful
-cd <name of work area subdirectory>
-```
+If you wish to develop DUNE DAQ software, you can start by creating a work area. Find a directory in which you want your work area to be a subdirectory (home directories are a popular choice) and `cd` into that directory. Then think of a good name for the work area (give it any name, but we'll refer to it as "MyTopDir" in this document).
 
-If you want to build against a candidate release (which is built and deployed during the beta testing period of a release cycle), run:
-```sh
-dbt-create -b candidate <candidate release> <name of work area subdirectory> # E.g., rc-dunedaq-v3.0.0-1 as of May-23-2022.
-cd <name of work area subdirectory>
-```
-The second of the two commands above is important: remember to `cd` into the subdirectory you just created after `dbt-create` finishes running. 
+Each work area is based on a DUNE DAQ software release, which defines what external and DUNE DAQ packages the code you develop in a work area are built against. Releases come in four categories:
+* **Nightly Releases**: packages in nightly releases are built each night using the heads of their `develop` branches. Depending on whether it's the far detector stack or the near detector stack, these are generally labeled either as `NFD<YY>-<MM>-<DD>` (far detector) or `NND<YY>-<MM>-<DD>` (near detector). E.g. `NFD23-07-15` is the nightly build for the far detector on July 15, 2023.
+* **Frozen Releases**: a frozen release typically comes out every couple of months, and only after extensive testing supervised by a Release Coordinator. Depending on whether it's the far detector stack or the near detector stack, labeled as `fddaq-vX.Y.X` or `nddaq-vX.Y.Z`. 
+* **Candidate Releases**: a type of release meant specifically for frozen release testing. Generally labeled as `fd-vX.Y.Z-<candidate iteration>` or `nd-vX.Y.Z-<candidate iteration>`, e.g. `fd-v4.1.0-c5`
 
-To see all available nightly releases, run `dbt-create -l -n` or `dbt-create -l -b nightly`. To see all available candidate releases, run `dbt-create -l -b candidate`. Less common but also possible is to build your repos not against a nightly release but against a frozen release; the commands you pass to `dbt-create` are the same, but with the `-n` or `-b <option>` dropped. 
+The majority of work areas are set up to build against the most recent nightly release. To do so, run:
+```sh
+dbt-create -n <nightly release> <name of work area subdirectory> # E.g., NFD23-07-15
+```
+To see all available nightly releases, run `dbt-create -l -n` or `dbt-create -l -b nightly`.
+
+If you want to build against a candidate release, run:
+```sh
+dbt-create -b candidate <candidate release> <name of work area subdirectory> # E.g., fd-v4.1.0-c5 
+```
+...where to see all available candidate releases, run `dbt-create -l -b candidate`.
+
+And to build against a frozen release (_not recommended_, as the codebase changes fairly rapidly), you don't need the `-b <release type>` argument at all. You can just do:
+```
+dbt-create <frozen release> <name of work area subdirectory> 
+```
 
 The structure of your work area will look like the following:
 ```txt
 MyTopDir
 ├── build
-├── dbt-pyvenv
-├── dbt-env.sh -> /path/to/daq-buildtools/env.sh
 ├── dbt-workarea-constants.sh
+├── env.sh
 ├── log
 └── sourcecode
     ├── CMakeLists.txt
@@ -102,6 +103,8 @@ Along with telling `dbt-create` what you want your work area to be named and wha
 
 ### The basics
 
+First step: `cd` into the base of the work area you've created. 
+
 For the purposes of instruction, let's build the `listrev` package. Downloading it is simple:
 ```
 cd sourcecode
@@ -112,22 +115,19 @@ cd ..
 Note that in a "real world" situation [you'd be doing your development on a feature branch](https://dune-daq-sw.readthedocs.io/en/latest/packages/daq-release/development_workflow_gitflow/) in which case you'd add `-b <branch you want to work on>` to the `git clone` command above. 
 
 
-We're about to build and install the `listrev` package. (&#x1F534; Note: if you are working with other packages, have a look at the [Working with more repos](#working-with-more-repos) subsection before running the following build command.) By default, the scripts will create a subdirectory of MyTopDir called `./install ` and install any packages you build off your repos there. If you wish to install them in another location, you'll want to set the environment variable `DBT_INSTALL_DIR` to the desired installation path before calling the `dbt-workarea-env` command described below. You'll also want to remember to set the variable during subsequent logins to the work area if you don't go with the default. 
+We're about to build and install the `listrev` package. (&#x1F534; Note: if you are working with other packages, have a look at the [Working with more repos](#working-with-more-repos) subsection before running the following build command.) By default, the scripts will create a subdirectory of MyTopDir called `./install ` and install any packages you build off your repos there. If you wish to install them in another location, you'll want to set the environment variable `DBT_INSTALL_DIR` to the desired installation path before source-ing the `env.sh` script described below. You'll also want to remember to set the variable during subsequent logins to the work area if you don't go with the default. 
 
 Now, do the following:
 ```sh
-dbt-workarea-env  # To set up your work area's environment
+. ./env.sh  # To set up your work area's environment
 dbt-build
 ```
-...and this will build `listrev` in the local `./build` subdirectory and then install it as a package either in the local `./install` subdirectory or in whatever you pointed `DBT_INSTALL_DIR` to. Note that whenever you add a new repo to your work area, you'll want to rerun `dbt-workarea-env` so that environment variables such as `LD_LIBRARY_PATH`, etc, are updated accordingly. 
+...and this will build `listrev` in the local `./build` subdirectory and then install it as a package either in the local `./install` subdirectory or in whatever you pointed `DBT_INSTALL_DIR` to. `env.sh` performs two steps: it will both set up the daq-buildtools environment (if it hasn't already been set) and then it will update environment variables (`LD_LIBRARY_PATH`, etc.) to account for the packages in your work area. Note that whenever you add a new repo to your work area, you'll want to run the second of these two steps, `dbt-workarea-env`, so that environment variables such as `LD_LIBRARY_PATH`, etc, are again updated accordingly. 
 
 
 ### Working with more repos
 
-To work with more repos, add them to the `./sourcecode` subdirectory as we did with listrev. Be aware, though: if you're developing a new repo which itself depends on another new repo, daq-buildtools may not already know about this dependency. "New" in this context means "not listed in `/cvmfs/dunedaq.opensciencegrid.org/releases/dunedaq-v2.11.0-c7/dbt-build-order.cmake`". If this is the case, you have one of two options:
-
-* (Recommended) Add the names of your new packages to the `build_order` list found in `./sourcecode/dbt-build-order.cmake`, placing them in the list in the relative order in which you want them to be built. 
-* First clone and build your new base repo, and THEN clone and build your other new repo which depends on your new base repo. 
+To work with more repos, add them to the `./sourcecode` subdirectory as we did with listrev. Be aware, though: if you're developing a new repo which itself depends on another new repo, daq-buildtools may not already know about this dependency. "New" in this context means "not listed in `/cvmfs/dunedaq.opensciencegrid.org/spack/releases/fddaq-v4.1.1/dbt-build-order.cmake`". If this is the case, add the names of your new package(s) to the `build_order` list found in `./sourcecode/dbt-build-order.cmake`, placing them in the list in the relative order in which you want them to be built. 
 
 As a reminder, once you've added your repos and built them, you'll want to run `dbt-workarea-env` so the environment picks up their applications, libraries, etc. 
 
@@ -149,9 +149,9 @@ To check for deviations from the coding rules described in the [DUNE C++ Style G
 ```
 dbt-build --lint
 ```
-...though be aware that some guideline violations (e.g., having a function which tries to do unrelated things) can't be picked up by the automated linter. Also note that you can use `dbt-clang-format.sh` in order to automatically fix whitespace issues in your code; type it at the command line without arguments to learn how to use it. (_n.b. Apr-11-2022: dbt-clang-format.sh is not yet supported for Spack-based work areas_)
+...though be aware that some guideline violations (e.g., having a function which tries to do unrelated things) can't be picked up by the automated linter. Also note that you can use `dbt-clang-format.sh` in order to automatically fix whitespace issues in your code; type it at the command line without arguments to learn how to use it.
 
-Note that unlike the other options to `dbt-build`, `--lint` and `--unittest` are both capable of taking an optional argument, which is the name of a specific repo in your work area which you'd like to either lint or run unit tests for. This can be useful if you're focusing on developing one of several repos in your work area. It should appear after an equals sign, e.g., `dbt-build --lint=<repo you're working on>`. With `--lint` you can get even more fine grained by passing it the name of a single file in your repository area; either the absolute path for the file or its path relative to the directory you ran `dbt-build` from will work. 
+Note that unlike the other options to `dbt-build`, `--lint` and `--unittest` are both capable of taking an optional argument, which is the name of a specific repo in your work area which you'd like to either lint or run unit tests for. This can be useful if you're focusing on developing one of several repos in your work area; e.g. `dbt-build --lint <repo you're working on>`. With `--lint` you can get even more fine grained by passing it the name of a single file in your repository area; either the absolute path for the file or its path relative to the directory you ran `dbt-build` from will work. 
 
 If you want to see verbose output from the compiler, all you need to do is add the `--cpp-verbose` option:
 ```
@@ -173,23 +173,19 @@ Finally, note that both the output of your builds and your unit tests are logged
 
 ## Running
 
-In order to access the applications, libraries and plugins built and installed into the `$DBT_INSTALL_DIR` area during the above procedure, the system needs to be instructed on where to look for them. This is accomplished via tha `dbt-workarea-env` command you've already seen. E.g., log into a new shell and set up the daq-buildtools environment as described at the top of this document, cd into your work area, then do the following:
+In order to access the applications, libraries and plugins built and installed into the `$DBT_INSTALL_DIR` area during the above procedure, the system needs to be instructed on where to look for them. This is accomplished via tha `env.sh` file you've already seen. E.g., log into a new shell, cd into your work area, then do the following:
 ```
-export DBT_INSTALL_DIR=<your installation directory> # Only needed if you didn't use the default
-dbt-workarea-env
+export DBT_INSTALL_DIR=<your installation directory> # ONLY needed if you didn't use the default
+. ./env.sh
 ```
-
-
 Note that if you add a new repo to your work area, after building your new code - and hence putting its output in `./build` - you'll need to run `dbt-workarea-env`.
 
 Once the runtime environment is set, just run the application you need. listrev, however, has no applications; it's just a set of DAQ module plugins which get added to CET_PLUGIN_PATH.  
 
 
-Now that you know how to set up a work area, a nice place to learn a bit about the DUNE DAQ suite is via the `daqconf` package. Take a look at its documentation [here](https://dune-daq-sw.readthedocs.io/en/latest/packages/daqconf/); note that in parts of the `daqconf` instructions you're told to run daq-buildtools commands which you may already have run (e.g., to create a new work area) in which case you can skip those specific commands.
+Now that you know how to set up a work area, a classic option for learning about how to run DAQ modules in a work area is [the listrev documentation](https://dune-daq-sw.readthedocs.io/en/latest/packages/listrev/).
 
-A classic option for learning about how to run DAQ modules in a work area is [the listrev documentation](https://dune-daq-sw.readthedocs.io/en/latest/packages/listrev/).
-
-In both the links above you'll notice you'll be running a program called `nanorc` to run the DAQ. To learn more about `nanorc` itself, take a look at [the nanorc documentation](https://dune-daq-sw.readthedocs.io/en/latest/packages/nanorc/).
+In the listrev instructions you'll be running a program called `nanorc` to run the DAQ. To learn more about `nanorc` itself, take a look at [the nanorc documentation](https://dune-daq-sw.readthedocs.io/en/latest/packages/nanorc/).
 
 
 <a name="Finding_Info"></a>
@@ -199,23 +195,28 @@ A couple of things need to be kept in mind when you're building code in a work a
 
 As such, it's important to know the assumptions a work area makes when you use it to build code. In the base of your work area is a file called `dbt-workarea-constants.sh`, which will look something like the following:
 ```
-export SPACK_RELEASE="NFD23-06-20"
-export SPACK_RELEASES_DIR="/cvmfs/dunedaq-development.opensciencegrid.org/nightly"
-export DBT_ROOT_WHEN_CREATED="/home/jcfree/daq-buildtools"
-export LOCAL_SPACK_DIR="/home/jcfree/daqbuild_test_mypackage/.spack"
+export SPACK_RELEASE="fddaq-v4.1.0"
+export SPACK_RELEASES_DIR="/cvmfs/dunedaq.opensciencegrid.org/spack/releases"
+export DBT_ROOT_WHEN_CREATED="/cvmfs/dunedaq.opensciencegrid.org/tools/dbt/v7.2.1"                         
+export LOCAL_SPACK_DIR="/home/jcfree/daqbuild_fddaq-v4.1.0/.spack"
 ```
 This file is sourced whenever you run `dbt-workarea-env`, and it tells both the build system and the developer where they can find crucial information about the work areas' builds. Specifically, these environment variables mean the following:
-* `$SPACK_RELEASE`: this is the release of the DUNE DAQ software stack against which repos will build (e.g. `dunedaq-v2.10.2`, `N22-04-09`, etc.)
-* `$SPACK_RELEASES_DIR`: The base of the directory containing the DUNE DAQ software installations. The directory `$SPACK_RELEASES_DIR/$SPACK_RELEASE` contains the installation of the packages for your release
+* `$SPACK_RELEASE`: this is the release of the DUNE DAQ software stack against which repos will build (e.g. `fddaq-v4.1.0`, `NFD23-07-15`, etc.)
+* `$SPACK_RELEASES_DIR`: The base of the directory containing the DUNE DAQ software installations. 
 * `DBT_ROOT_WHEN_CREATED`: The directory containing the `env.sh` file which was sourced before this work area was first created
 * `LOCAL_SPACK_DIR`: If the `-s/--spack` was passed to `dbt-create` when the work area was built, this points to where the local Spack area is located
 
-There are also useful Spack commands which can be executed to learn about the versions of the individual packages you're working with. An [excellent Spack tutorial](https://spack-tutorial.readthedocs.io/en/latest/tutorial_basics.html) inside the official Spack documentation is worth a look, but a few Spack commands can be used right away to learn about a work area:
-* `spack find --loaded -N | grep $SPACK_RELEASE` will tell you all the DUNE DAQ packages which have been loaded by `dbt-workarea-env` (or `dbt-setup-release`, for that matter)
-* `spack find --loaded -N | grep dunedaq-externals` is the same, but will tell you all the external packages
+There are also useful Spack commands which can be executed to learn about the versions of the individual packages you're working with, once you've run `dbt-workarea-env` or `dbt-setup-release`. An [excellent Spack tutorial](https://spack-tutorial.readthedocs.io/en/latest/tutorial_basics.html) inside the official Spack documentation is worth a look, but a few Spack commands can be used right away to learn more about your environment. They're presented both for the case of you having set up a nightly release and a frozen release:
+* `spack find --loaded -N | grep dunedaq-vX.Y.Z` or `spack find --loaded -N | grep NB` will tell you all the DUNE DAQ packages shared by both far- and near detector software which have been loaded by `dbt-workarea-env` or `dbt-setup-release`
+* `spack find --loaded -N | grep fddaq-vX.Y.Z` or `spack find --loaded -N | grep FD` for far detector DUNE DAQ packages
+* `spack find --loaded -N | grep nddaq-vX.Y.Z` or `spack find --loaded -N | grep ND` for near detector DUNE DAQ packages
+* `spack find --loaded -N | grep dunedaq-externals` for external packages not developed by DUNE collaborators
 * `spack find --loaded -p <package name>` will tell you the path to the actual contents of a Spack-installed package
 
+Finally, when `dbt-build` is run, a file called `daq_app_rte.sh` is
+produced and placed in your installation area (`$DBT_INSTALL_DIR`). You generally don't need to think about `daq_app_rte.sh` unless you're curious; it's a sourceable file which contains environment variables that [nanorc](https://dune-daq-sw.readthedocs.io/en/latest/packages/nanorc/) uses to launch processes when performing runs. 
 
 ## Next Step
 
 * You can learn how to create a new package by taking a look at the [daq-cmake documentation](https://dune-daq-sw.readthedocs.io/en/latest/packages/daq-cmake/)
+

--- a/scripts/dbt-setup-tools.sh
+++ b/scripts/dbt-setup-tools.sh
@@ -301,3 +301,74 @@ function stack_new_spack() {
     spack reindex
 }
 #------------------------------------------------------------------------------
+
+#------------------------------------------------------------------------------
+function load_yaml() {
+    python3 -c "import yaml;print(yaml.safe_load(open('$1'))$2)"
+}
+#------------------------------------------------------------------------------
+
+#------------------------------------------------------------------------------
+function dbt-pkg-info() {
+
+    local pkg=$1
+    local dunedaq_yaml=$(ls $(spack location -p dunedaq)/../../*.yaml|grep -v repo.yaml)
+    local dunedaq_pkgs=$(load_yaml $dunedaq_yaml "['dunedaq']"|sed "s/'/\"/g")
+
+    echo $dunedaq_pkgs|jq -c '.[] | select(.name=='\"$pkg\"')'
+
+    local release_yaml=""
+    local release_pkgs=""
+
+    if [[ "$SPACK_RELEASE" =~ (ND|nd) ]]; then
+        release_yaml=$(ls $(spack location -p nddaq)/../../*.yaml|grep -v repo.yaml)
+        release_pkgs=$(load_yaml $release_yaml "['nddaq']"|sed "s/'/\"/g")
+    fi
+    if [[ "$SPACK_RELEASE" =~ (FD|fd) ]]; then
+        release_yaml=$(ls $(spack location -p fddaq)/../../*.yaml|grep -v repo.yaml)
+        release_pkgs=$(load_yaml $release_yaml "['fddaq']"|sed "s/'/\"/g")
+    fi
+
+    echo $release_pkgs|jq -c '.[] | select(.name=='\"$pkg\"')'
+}
+#------------------------------------------------------------------------------
+
+#------------------------------------------------------------------------------
+function dbt-release-info() {
+
+    local release_type
+    local release_name
+    local base_release_name
+
+    local dunedaq_yaml=$(ls $(spack location -p dunedaq)/../../*.yaml|grep -v repo.yaml)
+    if [[ "$SPACK_RELEASE" =~ (ND|nd) ]]; then
+        release_yaml=$(ls $(spack location -p nddaq)/../../*.yaml|grep -v repo.yaml)
+    fi
+    if [[ "$SPACK_RELEASE" =~ (FD|fd) ]]; then
+        release_yaml=$(ls $(spack location -p fddaq)/../../*.yaml|grep -v repo.yaml)
+    fi
+    release_type=$(load_yaml $release_yaml "['type']")
+    release_name=$(load_yaml $release_yaml "['release']")
+    base_release_name=$(load_yaml $dunedaq_yaml "['release']")
+
+    echo "Release type: $release_type"
+    echo "Release name: $release_name"
+    echo "Base release: $base_release_name"
+}
+#------------------------------------------------------------------------------
+
+#------------------------------------------------------------------------------
+function dbt-src-status () {
+    if [ -z ${DBT_AREA_ROOT+x} ]; then
+        echo "DBT_AREA_ROOT is unset";
+        return
+    fi
+
+    for d in `ls -d ${DBT_AREA_ROOT}/sourcecode/*/`;
+    do
+        pushd $d > /dev/null;
+	echo "$d: $(git rev-parse --abbrev-ref HEAD)$(git diff --no-ext-diff --quiet --exit-code 2> /dev/null || echo -e \*)";
+	popd > /dev/null;
+    done
+}
+#------------------------------------------------------------------------------


### PR DESCRIPTION
* `dbt-pkg-info` takes one argument of a DAQ package name; if it's found in the release, the version and commit hash will be printed out;
* `dbt-release-info` will print out the current release type, whether it's fddaq or nddaq, the release name, and the base release name;
* `dbt-src-status` checks the status of of the source code in a workarea.