### PR TITLE
update funciton to exclude opt/spack/linux* directories when stacking…

### DIFF
--- a/scripts/dbt-setup-tools.sh
+++ b/scripts/dbt-setup-tools.sh
@@ -287,7 +287,7 @@ function stack_new_spack() {
     local existing_spack_dir=$1
     local new_spack_dir=$2
 
-    rsync -rlpt --exclude 'opt/spack/gcc*' --exclude 'spack-repo' $existing_spack_dir/* $new_spack_dir
+    rsync -rlpt --exclude 'opt/spack/gcc*' --exclude 'opt/spack/linux*' --exclude 'spack-repo' $existing_spack_dir/* $new_spack_dir
 
     mkdir -p $new_spack_dir/spack-repo/packages
     echo "repo:" > $new_spack_dir/spack-repo/repo.yaml


### PR DESCRIPTION
… local spack instance over the deployed release on cvmfs

Starting from `ext-v1.1` and `ext-v2.0`, the installation path of Spack packages include the Spack arch as subdirectories in it (e.g. `linux-almalinux9-x86_64`). When cloning the Spack configuration from the release delayed on cvmfs, the new installation path should be excluded.