### PR TITLE
tarball support when cloning python virtual env from cvmfs

### DIFF
--- a/bin/clonevirtualenv.py
+++ b/bin/clonevirtualenv.py
@@ -76,7 +76,11 @@ def clone_virtualenv(src_dir, dst_dir, tarball):
     #sys_path = _virtualenv_syspath(src_dir)
     logger.info('cloning virtualenv \'%s\' => \'%s\'...' %
             (src_dir, dst_dir))
-    if tarfile.is_tarfile(tarball):
+    found_tarball = False
+    if os.path.isfile(tarball):
+        if tarfile.is_tarfile(tarball):
+            found_tarball = True
+    if found_tarball:
         with tarfile.open(tarball,"r:gz") as tarfile_obj:
             tarfile_obj.extractall(os.path.dirname(dst_dir))
     else:

--- a/bin/clonevirtualenv.py
+++ b/bin/clonevirtualenv.py
@@ -78,7 +78,7 @@ def clone_virtualenv(src_dir, dst_dir, tarball):
             (src_dir, dst_dir))
     if tarfile.is_tarfile(tarball):
         with tarfile.open(tarball,"r:gz") as tarfile_obj:
-            tarfile_obj.extractfile(os.path.dirname(dst_dir))
+            tarfile_obj.extractall(os.path.dirname(dst_dir))
     else:
         shutil.copytree(src_dir, dst_dir, symlinks=True)
     for rootDir, subdirs, filenames in os.walk(dst_dir):

--- a/bin/clonevirtualenv.py
+++ b/bin/clonevirtualenv.py
@@ -12,6 +12,7 @@ import sys
 import itertools
 import shutil
 import fnmatch
+import tarfile
 
 
 __version__ = '0.5.7'
@@ -67,7 +68,7 @@ def _virtualenv_sys(venv_path):
     return lines[0], list(filter(bool, lines[1:]))
 
 
-def clone_virtualenv(src_dir, dst_dir):
+def clone_virtualenv(src_dir, dst_dir, tarball):
     if not os.path.exists(src_dir):
         raise UserError('src dir %r does not exist' % src_dir)
     if os.path.exists(dst_dir):
@@ -75,7 +76,11 @@ def clone_virtualenv(src_dir, dst_dir):
     #sys_path = _virtualenv_syspath(src_dir)
     logger.info('cloning virtualenv \'%s\' => \'%s\'...' %
             (src_dir, dst_dir))
-    shutil.copytree(src_dir, dst_dir, symlinks=True)
+    if tarfile.is_tarfile(tarball):
+        with tarfile.open(tarball,"r:gz") as tarfile_obj:
+            tarfile_obj.extractfile(os.path.dirname(dst_dir))
+    else:
+        shutil.copytree(src_dir, dst_dir, symlinks=True)
     for rootDir, subdirs, filenames in os.walk(dst_dir):
         for filename in fnmatch.filter(filenames, '*.pyc'):
             try:
@@ -304,6 +309,12 @@ def main():
             dest='verbose',
             default=False,
             help='verbosity')
+    parser.add_option('-t',
+            '--tarball',
+            dest='tarball',
+            metavar="TAR_FILE",
+            default=None,
+            help='path to tarball in tar.gz format')
     options, args = parser.parse_args()
     try:
         old_dir, new_dir = args
@@ -316,7 +327,7 @@ def main():
             options.verbose)]
     logging.basicConfig(level=loglevel, format='%(message)s')
     try:
-        clone_virtualenv(old_dir, new_dir)
+        clone_virtualenv(old_dir, new_dir, options.tarball)
     except UserError:
         e = sys.exc_info()[1]
         parser.error(str(e))

--- a/scripts/dbt-clone-pyvenv.sh
+++ b/scripts/dbt-clone-pyvenv.sh
@@ -51,7 +51,8 @@ else
     echo -e "${PARENT_VENV}. "
     echo -e "Depending on a variety of factors this can take from several seconds to several minutes..."
 
-    ${HERE}/../bin/clonevirtualenv.py ${PARENT_VENV} ${DBT_AREA_ROOT}/${DBT_VENV}
+    TARFILE=$(dirname ${PARENT_VENV})/venv.tar.gz
+    ${HERE}/../bin/clonevirtualenv.py ${PARENT_VENV} ${DBT_AREA_ROOT}/${DBT_VENV} -t $TARFILE
 
     test $? -eq 0 || error "Problem creating virtual_env ${DBT_VENV}. Exiting..." 
 


### PR DESCRIPTION
check if `venv.tar.gz` exists under release directory, if so, untar it into the work area instead of copy whole tree of `.venv` from cvmfs.

PS: Apologies for the "revert revert" commit... forgot that I was not on the feature branch before I pushed the commits.