### PR TITLE
Issue #270 spack disable local config

### DIFF
--- a/env.sh
+++ b/env.sh
@@ -13,7 +13,6 @@ HERE=$(cd $(dirname $(readlink -f ${BASH_SOURCE})) && pwd)
 
 # Avoid conflicts with local spack environment
 export SPACK_DISABLE_LOCAL_CONFIG=true
-export SPACK_USER_CACHE_PATH=/tmp/$USER/spack
 
 export DBT_ROOT=${HERE}
 

--- a/env.sh
+++ b/env.sh
@@ -13,7 +13,10 @@ HERE=$(cd $(dirname $(readlink -f ${BASH_SOURCE})) && pwd)
 
 # Avoid conflicts with local spack environment
 export SPACK_DISABLE_LOCAL_CONFIG=true
-export SPACK_USER_CACHE_PATH=/tmp/$USER/spack
+if [[ -z $DBT_AREA_ROOT ]]; then
+    echo "DBT_AREA_ROOT DNE; defaulting to /tmp"
+    export SPACK_USER_CACHE_PATH="/tmp/${USER}/spack"
+fi
 
 export DBT_ROOT=${HERE}
 
@@ -27,3 +30,4 @@ dbt-workarea-env() { source ${DBT_ROOT}/scripts/dbt-workarea-env.sh $@; }
 dbt-setup-release() { source ${DBT_ROOT}/scripts/dbt-setup-release.sh $@; }
 
 echo -e "${COL_GREEN}DBT setuptools loaded${COL_RESET}"
+

--- a/env.sh
+++ b/env.sh
@@ -11,12 +11,6 @@ fi
 #------------------------------------------------------------------------------
 HERE=$(cd $(dirname $(readlink -f ${BASH_SOURCE})) && pwd)
 
-# Avoid conflicts with local spack environment
-export SPACK_DISABLE_LOCAL_CONFIG=true
-if [[ -z $DBT_AREA_ROOT ]]; then
-    export SPACK_USER_CACHE_PATH="/tmp/${USER}/spack"
-fi
-
 export DBT_ROOT=${HERE}
 
 # Import add_many_paths function

--- a/env.sh
+++ b/env.sh
@@ -13,6 +13,7 @@ HERE=$(cd $(dirname $(readlink -f ${BASH_SOURCE})) && pwd)
 
 # Avoid conflicts with local spack environment
 export SPACK_DISABLE_LOCAL_CONFIG=true
+export SPACK_USER_CACHE_PATH=/tmp/$USER/spack
 
 export DBT_ROOT=${HERE}
 

--- a/env.sh
+++ b/env.sh
@@ -11,7 +11,9 @@ fi
 #------------------------------------------------------------------------------
 HERE=$(cd $(dirname $(readlink -f ${BASH_SOURCE})) && pwd)
 
+# Avoid conflicts with local spack environment
 export SPACK_DISABLE_LOCAL_CONFIG=true
+
 export DBT_ROOT=${HERE}
 
 # Import add_many_paths function

--- a/env.sh
+++ b/env.sh
@@ -11,6 +11,7 @@ fi
 #------------------------------------------------------------------------------
 HERE=$(cd $(dirname $(readlink -f ${BASH_SOURCE})) && pwd)
 
+export SPACK_DISABLE_LOCAL_CONFIG=true
 export DBT_ROOT=${HERE}
 
 # Import add_many_paths function

--- a/scripts/dbt-create-spack.sh
+++ b/scripts/dbt-create-spack.sh
@@ -35,6 +35,9 @@ fi
 if [[ -z $SPACK_RELEASES_DIR ]]; then
     error "Environment variable SPACK_RELEASES_DIR needs to be set for this script to work. Exiting..."
 fi
+if [[ -z $SPACK_USER_CACHE_PATH ]]; then
+    export SPACK_USER_CACHE_PATH=${DBT_AREA_ROOT}
+fi
 
 
 ###

--- a/scripts/dbt-workarea-env.sh
+++ b/scripts/dbt-workarea-env.sh
@@ -77,6 +77,7 @@ else
     return 3
 fi
 
+export SPACK_USER_CACHE_PATH=${DBT_AREA_ROOT}
 
 SOURCE_DIR="${DBT_AREA_ROOT}/sourcecode"
 BUILD_DIR="${DBT_AREA_ROOT}/build"

--- a/scripts/dbt_create.py
+++ b/scripts/dbt_create.py
@@ -175,8 +175,8 @@ export DBT_ROOT_WHEN_CREATED="{os.environ["DBT_ROOT"]}"
 
 if args.install_spack:
     # Avoid environment conflicts with local user spack directory
-    run_command("export SPACK_DISABLE_LOCAL_CONFIG=true")
-    run_command(f"export SPACK_USER_CACHE_PATH={TARGETDIR}")
+    os.environ["SPACK_DISABLE_LOCAL_CONFIG"] = "true"
+    os.environ["SPACK_USER_CACHE_PATH"] = f"{TARGETDIR}/.spack"
     user_spack_dir = f'{os.environ["HOME"]}/.spack'
     if os.path.exists(user_spack_dir):
         print(f'WARNING A spack directory already exists at {user_spack_dir}.')

--- a/scripts/dbt_create.py
+++ b/scripts/dbt_create.py
@@ -174,6 +174,10 @@ export DBT_ROOT_WHEN_CREATED="{os.environ["DBT_ROOT"]}"
 """
 
 if args.install_spack:
+    user_spack_dir = f'{os.environ["HOME"]}/.spack'
+    if os.path.exists(user_spack_dir):
+        print(f'WARNING A spack directory already exists at {user_spack_dir}.')
+        print(f'        This may cause environment conflicts with {TARGETDIR}/.spack')
     os.environ["LOCAL_SPACK_DIR"] = f"{TARGETDIR}/.spack"
     workarea_constants_file_contents += f"""export LOCAL_SPACK_DIR="{os.environ["LOCAL_SPACK_DIR"]}"
 """

--- a/scripts/dbt_create.py
+++ b/scripts/dbt_create.py
@@ -174,6 +174,9 @@ export DBT_ROOT_WHEN_CREATED="{os.environ["DBT_ROOT"]}"
 """
 
 if args.install_spack:
+    # Avoid environment conflicts with local user spack directory
+    run_command("export SPACK_DISABLE_LOCAL_CONFIG=true")
+    run_command(f"export SPACK_USER_CACHE_PATH={TARGETDIR}")
     user_spack_dir = f'{os.environ["HOME"]}/.spack'
     if os.path.exists(user_spack_dir):
         print(f'WARNING A spack directory already exists at {user_spack_dir}.')


### PR DESCRIPTION
This PR seeks to address Issue #270 by 
1. setting `SPACK_DISABLE_LOCAL_CONFIG=true` when `env.sh` is sourced, 
2. doing the same in `dbt_create.py` when `-s` is given as an argument, 
3. setting `SPACK_USER_CACHE_PATH` to the dev environment so that `$HOME/.spack/cache` isn't created, and 
4. printing warning is printed if `$HOME/.spack` already exists