### PR TITLE
Add `DUNE_DAQ_RELEASE_SOURCE` environment variable to `dbt-create`

### DIFF
--- a/bin/dbt-info
+++ b/bin/dbt-info
@@ -243,11 +243,17 @@ def sourcecode_info():
    repos = [os.path.join(codepath, d) for d in os.listdir(codepath) if os.path.isdir(os.path.join(codepath, d))]
 
    print()
-   for repo in repos:
-      os.chdir(repo)
-      print(f"%s: " % (repo.split("/")[-1]), end="")
-      run_command('echo -n \"$( git rev-parse --abbrev-ref HEAD )$( git diff --no-ext-diff --quiet --exit-code || echo \* ) \" ')
+   if repos:
+      print('Source code for locally checked out packages:')
+      for repo in repos:
+         os.chdir(repo)
+         print(f"%s: " % (repo.split("/")[-1]), end="")
+         run_command('echo -n \"$( git rev-parse --abbrev-ref HEAD )$( git diff --no-ext-diff --quiet --exit-code || echo \* ) \" ')
+   else: 
+      print('There are no locally checked out packages in $DBT_AREA_ROOT/sourcecode')
    print()
+
+   print(f"Source code for packages not checked out locally is in {os.environ.get('DUNE_DAQ_RELEASE_SOURCE')}")
 
 def full_help():
     release_help()

--- a/scripts/dbt_create.py
+++ b/scripts/dbt_create.py
@@ -104,7 +104,11 @@ elif not args.release_tag or not args.workarea_dir:
     error("Need to supply a release tag and a new work area directory. Run '{} -h' for more information.".format(os.path.basename(__file__)))
 
 RELEASE_PATH=os.path.realpath(f"{RELEASE_BASEPATH}/{args.release_tag}")
-os.environ["RELEASE_SOURCE_PATH"] = f"{RELEASE_PATH}/sourcecode"
+RELEASE_SOURCE_PATH=f"{RELEASE_PATH}/sourcecode"
+if not os.path.exists(RELEASE_SOURCE_PATH):
+    print(f'WARNING The environment variable DUNE_DAQ_RELEASE_SOURCE has been set')
+    print(f'        to {RELEASE_SOURCE_PATH}, but this path does not exist.')
+os.environ["RELEASE_SOURCE_PATH"] = RELEASE_SOURCE_PATH
 RELEASE=RELEASE_PATH.rstrip("/").split("/")[-1]
 if RELEASE != args.release_tag:
     print(f"Release \"{args.release_tag}\" requested; interpreting this as release \"{RELEASE}\"")

--- a/scripts/dbt_create.py
+++ b/scripts/dbt_create.py
@@ -104,6 +104,7 @@ elif not args.release_tag or not args.workarea_dir:
     error("Need to supply a release tag and a new work area directory. Run '{} -h' for more information.".format(os.path.basename(__file__)))
 
 RELEASE_PATH=os.path.realpath(f"{RELEASE_BASEPATH}/{args.release_tag}")
+os.environ["RELEASE_SOURCE_PATH"] = f"{RELEASE_PATH}/sourcecode"
 RELEASE=RELEASE_PATH.rstrip("/").split("/")[-1]
 if RELEASE != args.release_tag:
     print(f"Release \"{args.release_tag}\" requested; interpreting this as release \"{RELEASE}\"")
@@ -171,6 +172,7 @@ workarea_constants_file_contents = \
     f"""export SPACK_RELEASE="{os.environ["SPACK_RELEASE"]}"
 export SPACK_RELEASES_DIR="{os.environ["SPACK_RELEASES_DIR"]}"
 export DBT_ROOT_WHEN_CREATED="{os.environ["DBT_ROOT"]}"
+export DUNE_DAQ_RELEASE_SOURCE="{os.environ["RELEASE_SOURCE_PATH"]}"
 """
 
 if args.install_spack:

--- a/scripts/dbt_create.py
+++ b/scripts/dbt_create.py
@@ -106,8 +106,9 @@ elif not args.release_tag or not args.workarea_dir:
 RELEASE_PATH=os.path.realpath(f"{RELEASE_BASEPATH}/{args.release_tag}")
 RELEASE_SOURCE_PATH=f"{RELEASE_PATH}/sourcecode"
 if not os.path.exists(RELEASE_SOURCE_PATH):
-    print(f'WARNING The environment variable DUNE_DAQ_RELEASE_SOURCE has been set')
-    print(f'        to {RELEASE_SOURCE_PATH}, but this path does not exist.')
+    print(f'WARNING The environment variable DUNE_DAQ_RELEASE_SOURCE has been set to')
+    print(f'        {RELEASE_SOURCE_PATH},')
+    print(f'        but this path does not exist.')
 os.environ["RELEASE_SOURCE_PATH"] = RELEASE_SOURCE_PATH
 RELEASE=RELEASE_PATH.rstrip("/").split("/")[-1]
 if RELEASE != args.release_tag:


### PR DESCRIPTION
This PR, in combination with DUNE-DAQ/daq-release#381, implements the environment variable `DUNE_DAQ_RELEASE_SOURCE`, which points to a directory on `/cvmfs` containing the sourcecode used in the created release. Example usage:
```
source /cvmfs/dunedaq.opensciencegrid.org/setup_dunedaq.sh
git clone https://github.com/DUNE-DAQ/daq-buildtools.git -b amogan/daq_release_issue375
source daq-buildtools/env.sh
dbt-create -n NFDT_DEV_240624_A9 test_new_dbt # Test nightly created using the modified workflows in the linked PR above
cd test_new_dbt && source env.sh
echo $DUNE_DAQ_RELEASE_SOURCE
```
The last command outputs
```
/cvmfs/dunedaq-development.opensciencegrid.org/nightly/NFDT_DEV_240624_A9/sourcecode
```
and an `ls` in that directory shows all relevant packages. 

In the case where the `sourcecode` directory does not exist, `dbt-create` will print a warning and `DUNE_DAQ_RELEASE_SOURCE` will still be set to the non-existent `sourcecode` area:
```
WARNING The environment variable DUNE_DAQ_RELEASE_SOURCE has been set to
        /cvmfs/dunedaq-development.opensciencegrid.org/nightly/NFD_DEV_240620_A9/sourcecode,
        but this path does not exist.
```

