### PR TITLE
Replace getcwd with getenv("PWD") to avoid symlink dereferencing

### DIFF
--- a/bin/dbt-build
+++ b/bin/dbt-build
@@ -64,14 +64,11 @@ Usage
 
 """
 
-print("AAAA")
 BASEDIR=find_work_area()
-print(f"AAAA {BASEDIR}")
 
 if not os.path.exists(BASEDIR):
     error(f"Work area directory \"{BASEDIR}\" not found. Exiting...")
 
-raise SystemExit(0)
 
 BUILDDIR=f"{BASEDIR}/build"
 LOGDIR=f"{BASEDIR}/log"

--- a/bin/dbt-build
+++ b/bin/dbt-build
@@ -33,7 +33,7 @@ sys.path.append(f'{DBT_ROOT}/scripts')
 from dbt_setup_tools import error, find_work_area, get_time
 import pytee
 
-orig_working_dir=os.getcwd()
+orig_working_dir=os.getenv('PWD')
 
 def get_package_list( build_dir ) :
     return sh.find(rf"-L {build_dir} -mindepth 1 -maxdepth 1 -type d -not -name CMakeFiles  -printf %f\n".split()).split()
@@ -64,9 +64,14 @@ Usage
 
 """
 
+print("AAAA")
 BASEDIR=find_work_area()
+print(f"AAAA {BASEDIR}")
+
 if not os.path.exists(BASEDIR):
     error(f"Work area directory \"{BASEDIR}\" not found. Exiting...")
+
+raise SystemExit(0)
 
 BUILDDIR=f"{BASEDIR}/build"
 LOGDIR=f"{BASEDIR}/log"
@@ -138,7 +143,7 @@ os.chdir(BUILDDIR)
 
 if args.clean_build or args.codegen_only:
     # Want to be damn sure we're in the right directory, recursive directory removal is no joke...
-    if os.path.basename(os.getcwd()) == "build":
+    if os.path.basename(os.getenv('PWD')) == "build":
 
         if not force_clean:
             rich.print(f"""
@@ -147,15 +152,15 @@ if args.clean_build or args.codegen_only:
             """)
             sleep(5)
 
-        for filename in os.listdir(os.getcwd()):
-            file_path = os.path.join(os.getcwd(), filename)
+        for filename in os.listdir(os.getenv('PWD')):
+            file_path = os.path.join(os.getenv('PWD'), filename)
             if os.path.isfile(file_path) or os.path.islink(file_path):
                 os.unlink(file_path)
             elif os.path.isdir(file_path):
                 rmtree(file_path)
     else:
         error(f"""
-You requested a clean build, but this script thinks that {os.getcwd()} isn't
+You requested a clean build, but this script thinks that {os.getenv('PWD')} isn't
 a build directory. Please contact John Freeman at jcfree@fnal.gov and notify him of this message.
         """)
 
@@ -437,11 +442,11 @@ if args.lint:
     datestring=re.sub("[: ]+", "_", stringio_obj8.getvalue().strip())
 
     if not os.path.exists("styleguide"):
-        rich.print(f"Cloning styleguide into {os.getcwd()} so linting can be applied")
+        rich.print(f"Cloning styleguide into {os.getenv('PWD')} so linting can be applied")
         sh.git("clone", "https://github.com/DUNE-DAQ/styleguide.git")
 
         if not os.path.exists("styleguide"):
-            error("There was a problem cloning the styleguide repo needed for linting into {}".format(os.getcwd()))
+            error("There was a problem cloning the styleguide repo needed for linting into {}".format(os.getenv('PWD')))
 
     code_to_lint_is_a_file = False
 

--- a/scripts/dbt_create.py
+++ b/scripts/dbt_create.py
@@ -144,10 +144,10 @@ starttime_s=get_time("as_seconds_since_epoch")
 try:
     pathlib.Path(TARGETDIR).mkdir(parents=True)
 except PermissionError:
-    error(f"You don't have permission to create {TARGETDIR} from {os.getcwd()}. Exiting...")
+    error(f"You don't have permission to create {TARGETDIR} from {os.getenv('PWD')}. Exiting...")
 
 os.chdir(TARGETDIR)
-TARGETDIR=os.getcwd() # Get full path
+TARGETDIR=os.getenv('PWD') # Get full path
 
 BUILDDIR=f"{TARGETDIR}/build"
 LOGDIR=f"{TARGETDIR}/log"

--- a/scripts/dbt_setup_tools.py
+++ b/scripts/dbt_setup_tools.py
@@ -20,9 +20,10 @@ def error(errmsg):
     sys.exit(1)
 
 def find_work_area():
-    currdir=os.getcwd()
+    currdir=os.getenv('PWD')
 
     while True:
+        print(currdir)
         if os.path.exists("{}/{}".format(currdir, DBT_AREA_FILE)):
             return currdir
         elif currdir != "":
@@ -35,7 +36,7 @@ def list_releases(release_basepath):
     versions = []
     base_release_regex_signifiers = ["^dunedaq-", "^NB", "^rc-", "^coredaq-"]
 
-    origdir=os.getcwd()
+    origdir=os.getenv('PWD')
     os.chdir(f"{release_basepath}")
     for dirname in glob.glob(f"*"):
         if os.path.isfile(dirname):


### PR DESCRIPTION
This change allows executing `dbt-build` from within simlinked directories