### PR TITLE
Use parsed release name for default directory when -n is used

### DIFF
--- a/scripts/dbt_create.py
+++ b/scripts/dbt_create.py
@@ -124,7 +124,7 @@ for a candidate release build. Exiting...""")
 if args.workarea_dir:
     TARGETDIR=args.workarea_dir
 else:
-    TARGETDIR=args.release_tag
+    TARGETDIR=RELEASE
 
 if os.path.exists(TARGETDIR):
     error(f"""Desired work area directory 


### PR DESCRIPTION
Address #284. Cases tested:
- `dbt-create -n last_fddaq` correctly creates, in this case, `NFD_DEV_241009_A9`
- `dbt-create -n last_fddaq my_dir` creates `my_dir`, as expected
- `dbt-create -n NFD_DEV_241009_A9 <dir>` still behaves as usual whether `<dir>` is provided or not