### PR TITLE
Support for nightly code check workflow

### DIFF
--- a/bin/dbt-build
+++ b/bin/dbt-build
@@ -392,9 +392,8 @@ if run_tests:
         unittestdirs = stringio_obj7.getvalue().split()
 
         if len(unittestdirs) == 0:
-            echo_no_unittest = f"-e No unit tests written for package {pkgname}"
+            echo_no_unittest = f"-e \033[31mNo unit tests have been written for package {os.path.basename(pkgname)} \033[0m"
             pytee.run("echo", echo_no_unittest.split(), test_log_summary)
-            #rich.print(f"[red]No unit tests have been written for {pkgname}[/red]", file = sys.stderr)
             continue
 
         if not "BOOST_TEST_LOG_LEVEL" in os.environ:

--- a/bin/dbt-build
+++ b/bin/dbt-build
@@ -392,7 +392,9 @@ if run_tests:
         unittestdirs = stringio_obj7.getvalue().split()
 
         if len(unittestdirs) == 0:
-            rich.print(f"[red]No unit tests have been written for {pkgname}[/red]", file = sys.stderr)
+            echo_no_unittest = f"-e No unit tests written for package {pkgname}"
+            pytee.run("echo", echo_no_unittest.split(), test_log_summary)
+            #rich.print(f"[red]No unit tests have been written for {pkgname}[/red]", file = sys.stderr)
             continue
 
         if not "BOOST_TEST_LOG_LEVEL" in os.environ:

--- a/bin/dbt-clang-format.sh
+++ b/bin/dbt-clang-format.sh
@@ -136,14 +136,19 @@ function format_files() {
         local markdown_content="# Clang-Format Report\n"
     fi
     previous_package_name=""
+    echo "========Formatting files:========="
+    echo $files_to_format
 
     for orig_file in $files_to_format ; do
 
     this_package_name=$(echo "$orig_file" | cut -d '/' -f 1)
+    echo "This package is ${this_package_name}"
     if [[ "$this_package_name" != "$previous_package_name" ]]; then
         markdown_content+="## $this_package_name \n"
         markdown_content+="| Test | Status| \n| --- | --- |\n"
         previous_package_name=$this_package_name
+        echo "Previous package is now ${previous_package_name}"
+        echo "Current markdown content: ${markdown_content}"
     fi
 
 	echo "Processing ${orig_file}..."

--- a/bin/dbt-clang-format.sh
+++ b/bin/dbt-clang-format.sh
@@ -133,10 +133,18 @@ function format_files() {
     local files_to_format=$2
     local output_markdown_table=$3
     if $output_markdown_table ; then 
-        local markdown_content="| File | Status| \n| --- | --- |\n"
+        local markdown_content="# Clang-Format Report"
     fi
+    previous_package_name=""
 
     for orig_file in $files_to_format ; do
+
+    this_package_name=$(echo "$orig_file" | cut -d '/' -f 1)
+    if [[ "$this_package_name" != "$previous_package_name" ]]; then
+        markdown_content+="## $this_package_name \n"
+        markdown_content+="| Test | Status| \n| --- | --- |\n"
+        previous_package_name=$this_package_name
+    fi
 
 	echo "Processing ${orig_file}..."
 	tmpfile=/tmp/$( uuidgen )

--- a/bin/dbt-clang-format.sh
+++ b/bin/dbt-clang-format.sh
@@ -7,8 +7,9 @@ if [[ "$?" != 0 ]]; then
 fi
 
 view_only_option="--view-differences-only"
+print_markdown_option="--output-markdown-file"
 
-if [[ "$#" != "1" && "$#" != "2" ]]; then
+if [[ "$#" != "1" && "$#" != "2"  && "$#" != 3]]; then
 
 cat<<EOF >&2
 
@@ -23,6 +24,11 @@ of its subdirectories.
 If the optional $view_only_option argument is supplied, then
 instead of actually editing the files, it'll simply show what edits
 would be made
+
+If the optional $print_markdown_option argument is supplied, then
+it will output a .md summary file showing which files pass and don't
+pass the clang formatting. This is primarily intended as part of a 
+GitHub Action.
 
 EOF
 
@@ -104,6 +110,7 @@ if [[ "$?" != "0" ]]; then
     error "There was a problem copying ${DBT_ROOT}/configs/.clang-format to this directory. Exiting..."
 fi
 
+> files_to_format_list.txt
 
 function format_files() {
 

--- a/bin/dbt-clang-format.sh
+++ b/bin/dbt-clang-format.sh
@@ -188,7 +188,11 @@ files_to_format=""
 extensions="*.hpp *.cpp *.cxx *.hxx"
 
 if [[ -d $filename ]]; then
-    files_to_format=$( for extension in $extensions ; do find $filename -name $extension; done )
+    files_to_format=$( 
+        for extension in $extensions ; do 
+            find $filename -name $extension; 
+        done | sort -t '/' -k 2
+    )
 elif [[ -f $filename ]]; then
     extension=$( echo $filename | sed -r 's/.*\.([^.]+)$/\1/' )
 

--- a/bin/dbt-clang-format.sh
+++ b/bin/dbt-clang-format.sh
@@ -133,7 +133,7 @@ function format_files() {
     local files_to_format=$2
     local output_markdown_table=$3
     if $output_markdown_table ; then 
-        local markdown_content="# Clang-Format Report"
+        local markdown_content="# Clang-Format Report\n"
     fi
     previous_package_name=""
 

--- a/bin/dbt-clang-format.sh
+++ b/bin/dbt-clang-format.sh
@@ -142,13 +142,10 @@ function format_files() {
     for orig_file in $files_to_format ; do
 
     this_package_name=$(echo "$orig_file" | cut -d '/' -f 2)
-    echo "This package is ${this_package_name}"
     if [[ "$this_package_name" != "$previous_package_name" ]]; then
         markdown_content+="## $this_package_name \n"
         markdown_content+="| Test | Status| \n| --- | --- |\n"
         previous_package_name=$this_package_name
-        echo "Previous package is now ${previous_package_name}"
-        echo "Current markdown content: ${markdown_content}"
     fi
 
 	echo "Processing ${orig_file}..."

--- a/bin/dbt-clang-format.sh
+++ b/bin/dbt-clang-format.sh
@@ -141,7 +141,7 @@ function format_files() {
 
     for orig_file in $files_to_format ; do
 
-    this_package_name=$(echo "$orig_file" | cut -d '/' -f 1)
+    this_package_name=$(echo "$orig_file" | cut -d '/' -f 2)
     echo "This package is ${this_package_name}"
     if [[ "$this_package_name" != "$previous_package_name" ]]; then
         markdown_content+="## $this_package_name \n"

--- a/bin/dbt-clang-format.sh
+++ b/bin/dbt-clang-format.sh
@@ -145,14 +145,16 @@ function format_files() {
         if $output_markdown_table ; then
             markdown_content+="| $orig_file | :white_check_mark: Already formatted |\n"
         fi
-	elif ! $differences_only ; then
-	    echo "Updating $orig_file with new formatting"
-	    echo
+    else
         if $output_markdown_table ; then
             markdown_content+="| $orig_file | :x: Needs formatting |\n"
         fi
-	    mv $tmpfile $orig_file
-	fi
+        if ! $differences_only ; then
+            echo "Updating $orig_file with new formatting"
+            echo
+            mv $tmpfile $orig_file
+        fi
+    fi
     done
     
     if $output_markdown_table ; then

--- a/bin/dbt-clang-format.sh
+++ b/bin/dbt-clang-format.sh
@@ -7,7 +7,7 @@ if [[ "$?" != 0 ]]; then
 fi
 
 view_only_option="--view-differences-only"
-print_markdown_option="--output-markdown-file"
+output_markdown_option="--output-markdown-file"
 
 if [[ "$#" != "1" && "$#" != "2"  && "$#" != 3]]; then
 
@@ -25,7 +25,7 @@ If the optional $view_only_option argument is supplied, then
 instead of actually editing the files, it'll simply show what edits
 would be made
 
-If the optional $print_markdown_option argument is supplied, then
+If the optional $output_markdown_option argument is supplied, then
 it will output a .md summary file showing which files pass and don't
 pass the clang formatting. This is primarily intended as part of a 
 GitHub Action.
@@ -37,6 +37,7 @@ fi
 
 filename=$1
 arg2=$2
+arg3=$3
 
 if [[ ! -e $filename ]]; then
     error "Unable to find $filename; exiting..." 
@@ -49,6 +50,15 @@ if [[ -n $arg2 ]]; then
     else
 	error "Only allowed second argument is \"$view_only_option\""
     fi
+fi
+
+output_markdown_file=false
+if [[ -n $arg3 ]]; then
+    if [[ "$arg3" == "$output_markdown_option" ]]; then
+    output_markdown_file=true
+    else
+    error "Only allowed third argument is \"$output_markdown_option\""
+    fi 
 fi
 
 if [[ -z ${DBT_WORKAREA_ENV_SCRIPT_SOURCED:-} ]]; then
@@ -116,6 +126,10 @@ function format_files() {
 
     local differences_only=$1
     local files_to_format=$2
+    local output_markdown_table=$3
+    if $output_markdown_table ; then 
+        local markdown_content="| File | Status| \n| --- | --- |\n"
+    fi
 
     for orig_file in $files_to_format ; do
 
@@ -130,12 +144,22 @@ function format_files() {
 	    echo
 	    echo "$orig_file already properly formatted"
 	    echo
+        if $output_markdown_table ; then
+            markdown_content+="| $orig_file | :white_check_mark: Already formatted |\n"
+        fi
 	elif ! $differences_only ; then
 	    echo "Updating $orig_file with new formatting"
 	    echo
+        if $output_markdown_table ; then
+            markdown_content+="| $orig_file | :x: Needs formatting |\n"
+        fi
 	    mv $tmpfile $orig_file
 	fi
     done
+    
+    if $output_markdown_table ; then
+        echo -e $markdown_content > clang_format_summary_table.md
+    fi
 }
 
 files_to_format=""
@@ -153,7 +177,7 @@ elif [[ -f $filename ]]; then
     fi
 fi
 
-format_files true "$files_to_format"
+format_files true "$files_to_format" $output_markdown_file
 
 if ! $differences_only ; then
     

--- a/bin/dbt-clang-format.sh
+++ b/bin/dbt-clang-format.sh
@@ -6,59 +6,66 @@ if [[ "$?" != 0 ]]; then
     exit 1
 fi
 
-view_only_option="--view-differences-only"
-output_markdown_option="--output-markdown-file"
+print_usage() {
+    cat <<EOF >&2
 
-if [[ "$#" != "1" && "$#" != "2"  && "$#" != 3 ]]; then
+Usage: $(basename "$0") <file or directory to format> [ -v | --view-differences-only ] [ -m | --markdown-summary ]
 
-cat<<EOF >&2
-
-Usage: $(basename $0) <file or directory to examine> ( $view_only_option )
-
-Given a file, this script will apply clang-format to that file
+Given a file, this script will apply clang-format to that file.
 
 Given a directory, it will apply clang-format to all the
 source (*.cxx, *.cpp) and header (*.hpp) files in that directory as well as all
 of its subdirectories.
 
-If the optional $view_only_option argument is supplied, then
-instead of actually editing the files, it'll simply show what edits
-would be made
-
-If the optional $output_markdown_option argument is supplied, then
-it will output a .md summary file showing which files pass and don't
-pass the clang formatting. This is primarily intended as part of a 
-GitHub Action.
-
+Optional arguments:
+  -v | --view-differences-only    Show differences without applying them.
+  -m | --markdown-summary         Output results in markdown format.
 EOF
-
     exit 1
+}
+
+if [[ $# -eq 0 || $# -gt 3 ]]; then
+    print_usage
 fi
 
 filename=$1
-arg2=$2
-arg3=$3
+shift
+differences_only=false
+output_markdown_file=false
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -v|--view-differences-only)
+        if $differences_only ; then
+            error "The -v flag can only be used once. Exiting..."
+        fi
+        differences_only=true
+        shift
+        ;;
+    -m|--markdown-summary)
+        if $output_markdown_file ; then
+            error "The -m flag can only be used once. Exiting..."
+        fi
+        output_markdown_file=true
+        shift
+        ;;
+    --)
+        shift
+        break
+        ;;
+    -*)
+        echo "Invalid option: $1" >&2
+        exit 1
+        ;;
+    *)
+        echo "Unexpected argument: $1" >&2
+        exit 1
+        ;;
+  esac
+done
 
 if [[ ! -e $filename ]]; then
-    error "Unable to find $filename; exiting..." 
-fi
-
-differences_only=false
-if [[ -n $arg2 ]]; then
-    if [[ "$arg2" == "$view_only_option" ]]; then
-	differences_only=true
-    else
-	error "Only allowed second argument is \"$view_only_option\""
-    fi
-fi
-
-output_markdown_file=false
-if [[ -n $arg3 ]]; then
-    if [[ "$arg3" == "$output_markdown_option" ]]; then
-    output_markdown_file=true
-    else
-    error "Only allowed third argument is \"$output_markdown_option\""
-    fi 
+    error "Unable to find $filename; make sure to pass a file or directory name as the first argument. Exiting..." 
 fi
 
 if [[ -z ${DBT_WORKAREA_ENV_SCRIPT_SOURCED:-} ]]; then
@@ -125,6 +132,7 @@ function format_files() {
     local differences_only=$1
     local files_to_format=$2
     local output_markdown_table=$3
+    echo "MARKDOWN OPTION: $output_markdown_table"
     if $output_markdown_table ; then 
         local markdown_content="| File | Status| \n| --- | --- |\n"
     fi
@@ -160,7 +168,7 @@ function format_files() {
     if $output_markdown_table ; then
         markdown_file_name="clang_format_summary_table.md"
         echo -e $markdown_content > $markdown_file_name
-        echo "Markdown summary table saved as $(readlink -f $markdown_file_name)"
+        echo -e "Markdown summary table saved as $(readlink -f $markdown_file_name)\n"
     fi
 }
 
@@ -193,7 +201,7 @@ EOF
     while true; do
 	read -p "" yn
 	case $yn in
-            [Yy]* ) format_files false "$files_to_format"; break;;
+            [Yy]* ) format_files false "$files_to_format" false; break;;
             [Nn]* ) exit;;
             * ) echo "Please answer yes or no.";;
 	esac

--- a/bin/dbt-clang-format.sh
+++ b/bin/dbt-clang-format.sh
@@ -9,7 +9,7 @@ fi
 view_only_option="--view-differences-only"
 output_markdown_option="--output-markdown-file"
 
-if [[ "$#" != "1" && "$#" != "2"  && "$#" != 3]]; then
+if [[ "$#" != "1" && "$#" != "2"  && "$#" != 3 ]]; then
 
 cat<<EOF >&2
 
@@ -120,8 +120,6 @@ if [[ "$?" != "0" ]]; then
     error "There was a problem copying ${DBT_ROOT}/configs/.clang-format to this directory. Exiting..."
 fi
 
-> files_to_format_list.txt
-
 function format_files() {
 
     local differences_only=$1
@@ -158,7 +156,9 @@ function format_files() {
     done
     
     if $output_markdown_table ; then
-        echo -e $markdown_content > clang_format_summary_table.md
+        markdown_file_name="clang_format_summary_table.md"
+        echo -e $markdown_content > $markdown_file_name
+        echo "Markdown summary table saved as $(readlink -f $markdown_file_name)"
     fi
 }
 

--- a/bin/dbt-clang-format.sh
+++ b/bin/dbt-clang-format.sh
@@ -132,7 +132,6 @@ function format_files() {
     local differences_only=$1
     local files_to_format=$2
     local output_markdown_table=$3
-    echo "MARKDOWN OPTION: $output_markdown_table"
     if $output_markdown_table ; then 
         local markdown_content="| File | Status| \n| --- | --- |\n"
     fi

--- a/bin/dbt-unittest-summary.sh
+++ b/bin/dbt-unittest-summary.sh
@@ -4,6 +4,10 @@ COL_RED="\e[1;31m"
 COL_GREEN="\e[1;32m"
 
 source ${DBT_ROOT}/scripts/dbt-setup-tools.sh
+if [[ "$?" != 0 ]]; then
+    echo "The source of dbt-setup-tools.sh failed; this may mean you need to set up the dbt-buildtools environment. Exiting..." >&2
+    exit 1
+fi
 LOGDIR=${DBT_AREA_ROOT}/log
 test_log=$LOGDIR/unit_tests_$( date | sed -r 's/[: ]+/_/g' ).log
 

--- a/bin/dbt-unittest-summary.sh
+++ b/bin/dbt-unittest-summary.sh
@@ -4,30 +4,8 @@ COL_RED="\e[1;31m"
 COL_GREEN="\e[1;32m"
 
 source ${DBT_ROOT}/scripts/dbt-setup-tools.sh
-if [[ "$?" != 0 ]]; then
-    echo "The source of dbt-setup-tools.sh failed; this may mean you need to set up the dbt-buildtools environment. Exiting..." >&2
-    exit 1
-fi
 LOGDIR=${DBT_AREA_ROOT}/log
 test_log=$LOGDIR/unit_tests_$( date | sed -r 's/[: ]+/_/g' ).log
-output_markdown_file=false
-
-OPTS="m"
-while getopts $OPTS opt; do
-  case ${opt} in
-    m)
-      output_markdown_file=true
-      ;;
-    \?)
-      echo "Invalid option: -$OPTARG" >&2
-      exit 1
-      ;;
-    :)
-      echo "Option -$OPTARG requires an argument." >&2
-      exit 1
-      ;;
-  esac
-done
 
 function echo_success() {
   echo -e "${COL_GREEN}SUCCESS${COL_RESET}"

--- a/bin/dbt-unittest-summary.sh
+++ b/bin/dbt-unittest-summary.sh
@@ -10,6 +10,24 @@ if [[ "$?" != 0 ]]; then
 fi
 LOGDIR=${DBT_AREA_ROOT}/log
 test_log=$LOGDIR/unit_tests_$( date | sed -r 's/[: ]+/_/g' ).log
+output_markdown_file=false
+
+OPTS="m"
+while getopts $OPTS opt; do
+  case ${opt} in
+    m)
+      output_markdown_file=true
+      ;;
+    \?)
+      echo "Invalid option: -$OPTARG" >&2
+      exit 1
+      ;;
+    :)
+      echo "Option -$OPTARG requires an argument." >&2
+      exit 1
+      ;;
+  esac
+done
 
 function echo_success() {
   echo -e "${COL_GREEN}SUCCESS${COL_RESET}"


### PR DESCRIPTION
`daq-release` PR [#411](https://github.com/DUNE-DAQ/daq-release/pull/411) will add a nightly workflow which runs unit tests and clang formatting checks. In order to report the results of those tests in an easily digestible manner, this PR adds support for markdown output which can be used in [GitHub step summaries](https://github.blog/news-insights/product-news/supercharging-github-actions-with-job-summaries/#create-summaries). 

`dbt-build` will now use `pytee` to write a "no unit tests written" message to stdout as well as the summary log. This allows the nightly code check workflow to parse this information from the unit test summary log, which previously only noted success or failure of unit tests which already exist. 

`dbt-clang-format.sh` now has an optional command-line flag, `--markdown-summary`, which controls whether or not it outputs the clang formatting results to a `.md` file which can be used for the GitHub step summary. I also took this opportunity to improve the argument parsing in that script. 

The results of the nightly code check workflow, which currently uses this branch of `daq-buildtools`, can be seen [here](https://github.com/DUNE-DAQ/daq-release/actions/runs/11862774427). 