### PR TITLE
Separate build and run environments using `dev` variant

### DIFF
--- a/scripts/dbt-setup-release.sh
+++ b/scripts/dbt-setup-release.sh
@@ -150,7 +150,9 @@ target_package="unknown"
 [[ "$SPACK_RELEASE" =~ (FD|fd) ]] && target_package=fddaq
 
 # For dbt-setup-release, we don't need to drag in build-only dependencies
-spack_load_target_package $target_package ~dev
+variant="~~dev"
+
+spack_load_target_package $target_package $variant
 retval=$?
 if [[ "$retval" != "0" ]]; then
     error "Failed to load spack target package \"$target_package\". Returning..."

--- a/scripts/dbt-setup-release.sh
+++ b/scripts/dbt-setup-release.sh
@@ -149,7 +149,10 @@ target_package="unknown"
 [[ "$SPACK_RELEASE" =~ (ND|nd) ]] && target_package=nddaq
 [[ "$SPACK_RELEASE" =~ (FD|fd) ]] && target_package=fddaq
 
-spack_load_target_package $target_package
+# For dbt-setup-release, we don't need to drag in build-only dependencies
+variant="~~dev"
+
+spack_load_target_package $target_package $variant
 retval=$?
 if [[ "$retval" != "0" ]]; then
     error "Failed to load spack target package \"$target_package\". Returning..."

--- a/scripts/dbt-setup-release.sh
+++ b/scripts/dbt-setup-release.sh
@@ -47,7 +47,7 @@ Arguments and options:
 
     dunedaq-release: is the name of the release the running environment will be based on (e.g. dunedaq-v2.0.0)
     -n/--nightly: switch to nightly releases, shortcut for "-b/--base-release nightly"
-    -b/--base-release: base release type, choosing from ['frozen', 'nighlty', 'candidate', 'test'], default is 'frozen'.
+    -b/--base-release: base release type, choosing from ['frozen', 'nightly', 'candidate', 'test'], default is 'frozen'.
     -l/--list: show the list of available releases
     -r/--release-path: is the path to the release archive (defaults to either $PROD_BASEPATH (frozen) or $NIGHTLY_BASEPATH (nightly))
 

--- a/scripts/dbt-setup-release.sh
+++ b/scripts/dbt-setup-release.sh
@@ -150,7 +150,7 @@ target_package="unknown"
 [[ "$SPACK_RELEASE" =~ (FD|fd) ]] && target_package=fddaq
 
 # For dbt-setup-release, we don't need to drag in build-only dependencies
-variant="~~dev"
+variant="~dev"
 
 spack_load_target_package $target_package $variant
 retval=$?

--- a/scripts/dbt-setup-release.sh
+++ b/scripts/dbt-setup-release.sh
@@ -150,9 +150,7 @@ target_package="unknown"
 [[ "$SPACK_RELEASE" =~ (FD|fd) ]] && target_package=fddaq
 
 # For dbt-setup-release, we don't need to drag in build-only dependencies
-variant="~~dev"
-
-spack_load_target_package $target_package $variant
+spack_load_target_package $target_package ~dev
 retval=$?
 if [[ "$retval" != "0" ]]; then
     error "Failed to load spack target package \"$target_package\". Returning..."

--- a/scripts/dbt-setup-tools.sh
+++ b/scripts/dbt-setup-tools.sh
@@ -218,12 +218,12 @@ function spack_load_target_package() {
     local spack_pkgname=$1
     local spack_pkg
 
-    local pkg_variant=$2
+    local daq_pkg_variant=${2:-+dev}
 
-    if [[ $spack_pkgname =~ (nd|fd|core|dune)daq ]]; then
-        spack_pkg=$spack_pkgname@${SPACK_RELEASE}
+    if [[ $spack_pkgname =~ (nd|fd|core|dune)daq || $spack_pkgname == "externals" ]]; then
+        spack_pkg="$spack_pkgname@${SPACK_RELEASE} ${daq_pkg_variant}"
     else
-	local base_release=$( spack find --format "{version}" coredaq )
+	local base_release=$( spack find --format "{version}" coredaq ${daq_pkg_variant} )
 
 	# JCF, Apr-11-2024: Check and see if the old name for the core
 	# packages is used in this release

--- a/scripts/dbt-setup-tools.sh
+++ b/scripts/dbt-setup-tools.sh
@@ -218,6 +218,8 @@ function spack_load_target_package() {
     local spack_pkgname=$1
     local spack_pkg
 
+    local pkg_variant=$2
+
     if [[ $spack_pkgname =~ (nd|fd|core|dune)daq ]]; then
         spack_pkg=$spack_pkgname@${SPACK_RELEASE}
     else
@@ -243,9 +245,9 @@ function spack_load_target_package() {
 
 	local cmd=""
 	if [[ -n $SPACK_VERBOSE ]] && $SPACK_VERBOSE ; then
-	    cmd="spack --debug load $spack_pkg"
+	    cmd="spack --debug load $spack_pkg $pkg_variant" 
 	else
-	    cmd="spack load $spack_pkg"
+	    cmd="spack load $spack_pkg $pkg_variant"
 	fi
 
 

--- a/scripts/dbt-setup-tools.sh
+++ b/scripts/dbt-setup-tools.sh
@@ -220,15 +220,13 @@ function spack_load_target_package() {
 
     local daq_pkg_variant=${2:-+dev}
 
+    if ! spack find --variants $spack_pkgname | grep -q "$daq_pkg_variant"; then
+        daq_pkg_variant=""
+    fi
     if [[ $spack_pkgname =~ (nd|fd|core|dune)daq || $spack_pkgname == "externals" ]]; then
-        # For backwards compatibility, check for dev variant before loading it
-        if spack find --variants coredaq | grep -q "~dev"; then
-          spack_pkg="$spack_pkgname@${SPACK_RELEASE} ${daq_pkg_variant}"
-        else
-          spack_pkg="$spack_pkgname@${SPACK_RELEASE}"
-        fi
+        spack_pkg="$spack_pkgname@${SPACK_RELEASE}${daq_pkg_variant}"
     else
-	local base_release=$( spack find --format "{version}" coredaq ${daq_pkg_variant} )
+	local base_release=$( spack find --format "{version}" coredaq${daq_pkg_variant} )
 
 	# JCF, Apr-11-2024: Check and see if the old name for the core
 	# packages is used in this release

--- a/scripts/dbt-setup-tools.sh
+++ b/scripts/dbt-setup-tools.sh
@@ -220,9 +220,12 @@ function spack_load_target_package() {
 
     local daq_pkg_variant=${2:-+dev}
 
+    echo "spack find --variants: $(spack find --variants $spack_pkgname)"
     if ! spack find --variants $spack_pkgname | grep -q "$daq_pkg_variant"; then
         daq_pkg_variant=""
     fi
+    echo "Package name: $spack_pkgname"
+    echo "Variant: $daq_pkg_variant"
     if [[ $spack_pkgname =~ (nd|fd|core|dune)daq || $spack_pkgname == "externals" ]]; then
         spack_pkg="$spack_pkgname@${SPACK_RELEASE}${daq_pkg_variant}"
     else

--- a/scripts/dbt-setup-tools.sh
+++ b/scripts/dbt-setup-tools.sh
@@ -223,59 +223,59 @@ function spack_load_target_package() {
     if [[ $spack_pkgname =~ (nd|fd|core|dune)daq ]]; then
         spack_pkg=$spack_pkgname@${SPACK_RELEASE}
     else
-       local base_release=$( spack find --format "{version}" coredaq )
+	local base_release=$( spack find --format "{version}" coredaq )
 
-         # JCF, Apr-11-2024: Check and see if the old name for the core
-         # packages is used in this release
+	# JCF, Apr-11-2024: Check and see if the old name for the core
+	# packages is used in this release
 
-         if [[ "$base_release" =~ "No package matches the query" ]]; then
-             base_release=$( spack find --format "{version}" dunedaq )
-         fi
+	if [[ "$base_release" =~ "No package matches the query" ]]; then
+	    base_release=$( spack find --format "{version}" dunedaq )
+	fi
 
-         if [[ "$base_release" =~ "No package matches the query" ]]; then
-             spack_pkg=$spack_pkgname
-         else
-             spack_pkg=$spack_pkgname@${base_release}
-         fi
-     fi
+	if [[ "$base_release" =~ "No package matches the query" ]]; then
+	    spack_pkg=$spack_pkgname
+        else
+	    spack_pkg=$spack_pkgname@${base_release}
+	fi
+    fi
 
     pkg_loaded_status=$(spack find --loaded -l $spack_pkg | sed -r -n '/^\w{7} '$spack_pkgname'/p' )
     
     if [[ -z $pkg_loaded_status || $pkg_loaded_status =~ "0 loaded packages" || $pkg_loaded_status =~ "No package matches the query: $spack_pkgname" ]]; then
 
-    local cmd=""
-    if [[ -n $SPACK_VERBOSE ]] && $SPACK_VERBOSE ; then
-        cmd="spack --debug load $spack_pkg $pkg_variant" 
+	local cmd=""
+	if [[ -n $SPACK_VERBOSE ]] && $SPACK_VERBOSE ; then
+	    cmd="spack --debug load $spack_pkg $pkg_variant" 
+	else
+	    cmd="spack load $spack_pkg $pkg_variant"
+	fi
+
+
+	cat<<EOF
+
+This script is calling "$cmd"; it will print "Finished loading" 
+on successful completion. 
+
+If this is the first time the "spack load ..." command has been run in
+a while on this node it may take ~15 minutes; this is because cvmfs is
+populating its local cache. Please be patient; subsequent runs should
+take less than a minute.
+
+EOF
+	$cmd
+	retval=$?
+	if [[ "$retval" == "0" ]]; then
+	    echo "Finished loading"
+	else
+	    error "There was a problem calling ${cmd}"
+	    return $retval
+	fi
+	
     else
-        cmd="spack load $spack_pkg $pkg_variant"
+	spack find -p -l --loaded $spack_pkgname
+	error "There already appear to be \"$spack_pkgname\" packages loaded in; this is disallowed."
+	return 1
     fi
-
-
-    cat<<EOF
-
-  This script is calling "$cmd"; it will print "Finished loading" 
-  on successful completion. 
-
-  If this is the first time the "spack load ..." command has been run in
-  a while on this node it may take ~15 minutes; this is because cvmfs is
-  populating its local cache. Please be patient; subsequent runs should
-  take less than a minute.
-
-  EOF
-    $cmd
-    retval=$?
-    if [[ "$retval" == "0" ]]; then
-        echo "Finished loading"
-    else
-        error "There was a problem calling ${cmd}"
-        return $retval
-    fi
-    
-      else
-    spack find -p -l --loaded $spack_pkgname
-    error "There already appear to be \"$spack_pkgname\" packages loaded in; this is disallowed."
-    return 1
-      fi
 
 }
 #------------------------------------------------------------------------------

--- a/scripts/dbt-setup-tools.sh
+++ b/scripts/dbt-setup-tools.sh
@@ -223,59 +223,59 @@ function spack_load_target_package() {
     if [[ $spack_pkgname =~ (nd|fd|core|dune)daq ]]; then
         spack_pkg=$spack_pkgname@${SPACK_RELEASE}
     else
-	local base_release=$( spack find --format "{version}" coredaq )
+       local base_release=$( spack find --format "{version}" coredaq )
 
-	# JCF, Apr-11-2024: Check and see if the old name for the core
-	# packages is used in this release
+         # JCF, Apr-11-2024: Check and see if the old name for the core
+         # packages is used in this release
 
-	if [[ "$base_release" =~ "No package matches the query" ]]; then
-	    base_release=$( spack find --format "{version}" dunedaq )
-	fi
+         if [[ "$base_release" =~ "No package matches the query" ]]; then
+             base_release=$( spack find --format "{version}" dunedaq )
+         fi
 
-	if [[ "$base_release" =~ "No package matches the query" ]]; then
-	    spack_pkg=$spack_pkgname
-        else
-	    spack_pkg=$spack_pkgname@${base_release}
-	fi
-    fi
+         if [[ "$base_release" =~ "No package matches the query" ]]; then
+             spack_pkg=$spack_pkgname
+         else
+             spack_pkg=$spack_pkgname@${base_release}
+         fi
+     fi
 
     pkg_loaded_status=$(spack find --loaded -l $spack_pkg | sed -r -n '/^\w{7} '$spack_pkgname'/p' )
     
     if [[ -z $pkg_loaded_status || $pkg_loaded_status =~ "0 loaded packages" || $pkg_loaded_status =~ "No package matches the query: $spack_pkgname" ]]; then
 
-	local cmd=""
-	if [[ -n $SPACK_VERBOSE ]] && $SPACK_VERBOSE ; then
-	    cmd="spack --debug load $spack_pkg $pkg_variant" 
-	else
-	    cmd="spack load $spack_pkg $pkg_variant"
-	fi
-
-
-	cat<<EOF
-
-This script is calling "$cmd"; it will print "Finished loading" 
-on successful completion. 
-
-If this is the first time the "spack load ..." command has been run in
-a while on this node it may take ~15 minutes; this is because cvmfs is
-populating its local cache. Please be patient; subsequent runs should
-take less than a minute.
-
-EOF
-	$cmd
-	retval=$?
-	if [[ "$retval" == "0" ]]; then
-	    echo "Finished loading"
-	else
-	    error "There was a problem calling ${cmd}"
-	    return $retval
-	fi
-	
+    local cmd=""
+    if [[ -n $SPACK_VERBOSE ]] && $SPACK_VERBOSE ; then
+        cmd="spack --debug load $spack_pkg $pkg_variant" 
     else
-	spack find -p -l --loaded $spack_pkgname
-	error "There already appear to be \"$spack_pkgname\" packages loaded in; this is disallowed."
-	return 1
+        cmd="spack load $spack_pkg $pkg_variant"
     fi
+
+
+    cat<<EOF
+
+  This script is calling "$cmd"; it will print "Finished loading" 
+  on successful completion. 
+
+  If this is the first time the "spack load ..." command has been run in
+  a while on this node it may take ~15 minutes; this is because cvmfs is
+  populating its local cache. Please be patient; subsequent runs should
+  take less than a minute.
+
+  EOF
+    $cmd
+    retval=$?
+    if [[ "$retval" == "0" ]]; then
+        echo "Finished loading"
+    else
+        error "There was a problem calling ${cmd}"
+        return $retval
+    fi
+    
+      else
+    spack find -p -l --loaded $spack_pkgname
+    error "There already appear to be \"$spack_pkgname\" packages loaded in; this is disallowed."
+    return 1
+      fi
 
 }
 #------------------------------------------------------------------------------

--- a/scripts/dbt-setup-tools.sh
+++ b/scripts/dbt-setup-tools.sh
@@ -220,12 +220,10 @@ function spack_load_target_package() {
 
     local daq_pkg_variant=${2:-+dev}
 
-    echo "spack find --variants: $(spack find --variants $spack_pkgname)"
-    if ! spack find --variants $spack_pkgname | grep -q "$daq_pkg_variant"; then
+    # For backwards compatibility, only use a variant if it exists
+    if ! spack find --variants coredaq | grep -q "$daq_pkg_variant"; then
         daq_pkg_variant=""
     fi
-    echo "Package name: $spack_pkgname"
-    echo "Variant: $daq_pkg_variant"
     if [[ $spack_pkgname =~ (nd|fd|core|dune)daq || $spack_pkgname == "externals" ]]; then
         spack_pkg="$spack_pkgname@${SPACK_RELEASE}${daq_pkg_variant}"
     else
@@ -251,9 +249,9 @@ function spack_load_target_package() {
 
 	local cmd=""
 	if [[ -n $SPACK_VERBOSE ]] && $SPACK_VERBOSE ; then
-	    cmd="spack --debug load $spack_pkg $pkg_variant" 
+	    cmd="spack --debug load $spack_pkg"
 	else
-	    cmd="spack load $spack_pkg $pkg_variant"
+	    cmd="spack load $spack_pkg"
 	fi
 
 

--- a/scripts/dbt-setup-tools.sh
+++ b/scripts/dbt-setup-tools.sh
@@ -221,7 +221,12 @@ function spack_load_target_package() {
     local daq_pkg_variant=${2:-+dev}
 
     if [[ $spack_pkgname =~ (nd|fd|core|dune)daq || $spack_pkgname == "externals" ]]; then
-        spack_pkg="$spack_pkgname@${SPACK_RELEASE} ${daq_pkg_variant}"
+        # For backwards compatibility, check for dev variant before loading it
+        if spack find --variants coredaq | grep -q "~dev"; then
+          spack_pkg="$spack_pkgname@${SPACK_RELEASE} ${daq_pkg_variant}"
+        else
+          spack_pkg="$spack_pkgname@${SPACK_RELEASE}"
+        fi
     else
 	local base_release=$( spack find --format "{version}" coredaq ${daq_pkg_variant} )
 


### PR DESCRIPTION
This PR depends on [daq-release PR #119](https://github.com/DUNE-DAQ/daq-release/pull/419) which introduces the `dev` variant of the `externals`, `coredaq`, and `fddaq` umbrella packages. With these changes, `dbt-create` will create a build environment which includes `cmake`, `gdb`, and `ninja`, while `dbt-setup-release` will excludes those spack packages. This can be tested using the nightly `NFDU_DEV_241218_A9`, which was built using the `daq-release` branch `amogan/issue134_build_vs_run_environments` which installs both the `+dev` and `~dev` variants. I've confirmed locally that `which cmake` returns the system-level `cmake` when using this version of `dbt-setup-release`, while creating a local area with `dbt-create` and sourcing the local `env.sh` will pull in the spack `cmake` used by `externals`. 