### PR TITLE
Johnfreeman/issue289 code coverage

### DIFF
--- a/bin/dbt-lcov.sh
+++ b/bin/dbt-lcov.sh
@@ -1,126 +1,58 @@
 #!/bin/bash
 
-function print_usage() {
-                cat << EOU
-Usage
------
+if [[ -z $DBT_AREA_ROOT ]]; then
+    echo "Error: work area needs to be set up for this script to function. Exiting..." >&2
+    exit 1
+fi
 
-lcov has to be installed manually -- 
-https://github.com/linux-test-project/lcov/releases/tag/v1.15
-lcov-1.15-1.noarch.rpm
+cd $DBT_AREA_ROOT
 
-Upon success, the output will be in the "coverage" directory
-Load the file coverage/index.html in your browser to view the coverage report
+if [[ -z $( grep profile-arcs sourcecode/CMakeLists.txt ) ]]; then
 
-The following should be in CMakeLists.txt at or above the level of the code
-for which coverage information should be collected 
-(e.g. sourcecode/CMakeLists.txt, above its daq_add_subpackages call):
-
-SET(GCC_COVERAGE_COMPILE_FLAGS "-O0 -g -fprofile-arcs -ftest-coverage -fno-inline")
-SET(GCC_COVERAGE_LINK_FLAGS    "-lgcov")
-
-SET(CMAKE_CXX_FLAGS  "\${CMAKE_CXX_FLAGS} \${GCC_COVERAGE_COMPILE_FLAGS}")
-SET(CMAKE_EXE_LINKER_FLAGS  "\${CMAKE_EXE_LINKER_FLAGS} \${GCC_COVERAGE_LINK_FLAGS}")
-
-Coverage requires at least GCC v9_3_0 to work properly
+    echo -n "INSTRUMENTING YOUR sourcecode/CMakeLists.txt FILE FOR lcov..."
+    sleep 5
     
-EOU
-}
+sed  -i '/daq_add_subpackages("\${build_order}")/i \
+SET(GCC_COVERAGE_COMPILE_FLAGS "-O0 -g -fprofile-arcs -ftest-coverage -fno-inline")\
+SET(GCC_COVERAGE_LINK_FLAGS    "-lgcov")\
+SET(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} ${GCC_COVERAGE_COMPILE_FLAGS}")\
+SET(CMAKE_EXE_LINKER_FLAGS  "${CMAKE_EXE_LINKER_FLAGS} ${GCC_COVERAGE_LINK_FLAGS}")\n' sourcecode/CMakeLists.txt || exit 5
 
-if [ $# -gt 0 ]; then
-  print_usage
-  exit 0
+echo "done."
+
 fi
 
-source ${DBT_ROOT}/scripts/dbt-setup-tools.sh
-LOGDIR=${DBT_AREA_ROOT}/log
-lcov_log=$LOGDIR/lcov_report_$( date | sed -r 's/[: ]+/_/g' ).log
+dbt-build --clean || exit 3
 
-lcov_found=`type lcov >/dev/null 2>&1 && echo 0 || echo 1`
-if [ $lcov_found -ne 0 ]; then
-  echo "lcov executable not found!" >&2
-  echo
-  print_usage
-  exit 1
-fi
+output_dir="code_coverage_results"
+mkdir -p $output_dir
+cd $output_dir
 
-gccver=`gcc -v 2>&1|grep 'gcc version'|awk '{print $3}'|cut -d. -f1`
-if [ ${gccver:-0} -lt 9 ]; then
-  echo "GCC v9 or greater required for proper stats collection! (You have `gcc -v 2>&1|grep 'gcc version'|awk '{print $3}'`)" >&2
-  echo
-  print_usage
-  exit 2
-fi
+numerator_file=$PWD/code.numerator
+denominator_file=$PWD/code.denominator
 
-echo "Performing clean build, please wait" |& tee -a $lcov_log
-dbt-build --clean >$lcov_log 2>&1 || error "dbt-build --clean returned nonzero; exiting..."
-echo "Clean build complete. Setting up LCOV counters" |& tee -a $lcov_log
+spack load lcov || exit 3
 
-lcov -d $DBT_AREA_ROOT --zerocounters >>$lcov_log 2>&1 || error "lcov -d $DBT_AREA_ROOT --zerocounters returned nonzero; exiting..."
-lcov -c -i -d $DBT_AREA_ROOT -o  $DBT_AREA_ROOT/dunedaq.base >>$lcov_log 2>&1 || error "lcov -c -i -d $DBT_AREA_ROOT -o  $DBT_AREA_ROOT/dunedaq.base returned nonzero; exiting..."
+# Reset all execution counts to zero, if we've already run this script
+lcov  --zerocounters --directory $DBT_AREA_ROOT || exit 4
 
-# RUN THE TESTS
-dbt-unittest-summary.sh |& tee -a $lcov_log
+# The --ignore-errors argument below means we don't want an error over
+# a line mismatch between the source code and the coverage data. This
+# is thanks to our use of macros in our unit tests and elsewhere.
 
-       
-  COL_YELLOW="\e[33m"
-  COL_RESET="\e[0m"
-  COL_RED="\e[31m"
-  echo |& tee -a $lcov_log
-  echo |& tee -a $lcov_log
-  echo |& tee -a $lcov_log
+lcov -i --capture --directory $DBT_AREA_ROOT/build --output-file  $denominator_file --ignore-errors mismatch,mismatch --include "$DBT_AREA_ROOT/sourcecode/*" || exit 5
 
-  package_list=$( find -L  $DBT_INSTALL_DIR -mindepth 1 -maxdepth 1 -type d -not -name CMakeFiles )
+spack unload lcov || exit 6
 
-  for pkgname in $package_list ; do
+# Run the unit tests in our repos, and then we'll figure out what fraction of the code the tests hit
+dbt-build --unittest || exit 7
 
-    testdirs=$( find -L $pkgname/test -type d -name "bin" -not -regex ".*CMakeFiles.*" )
+spack load lcov || exit 8
 
-    if [[ -z $testdirs ]]; then
-      echo |& tee -a $lcov_log
-      echo -e "${COL_RED}No test applications or scripts for $pkgname${COL_RESET}" |& tee -a $lcov_log
-      echo |& tee -a $lcov_log
-      continue
-    fi
+lcov --capture --directory $DBT_AREA_ROOT/build --output-file  $numerator_file  --ignore-errors mismatch,mismatch --include "$DBT_AREA_ROOT/sourcecode/*" || exit 9
 
-    num_tests=0
+lcov --add-tracefile $denominator_file --add-tracefile $numerator_file --output-file $PWD/code.result || exit 10
 
-    for testdir in $testdirs; do
-      echo |& tee -a $lcov_log
-      echo |& tee -a $lcov_log
-      echo "RUNNING TESTS IN $testdir" |& tee -a $lcov_log
-      echo "======================================================================" |& tee -a $lcov_log
-      for atest in $testdir/* ; do
-        if [[ -x $atest ]]; then
-          echo |& tee -a $lcov_log
-          echo -e "${COL_YELLOW}Start of test \"$atest\"${COL_RESET}" |& tee -a $lcov_log
-          $atest |& tee -a $lcov_log
-          echo -e "${COL_YELLOW}End of test \"$atest\"${COL_RESET}" |& tee -a $lcov_log
-          num_tests=$((num_tests + 1))
-        fi
-      done
+genhtml --demangle-cpp -o  $PWD/html  $PWD/code.result || exit 11
 
-    done
-
-    echo  |& tee -a $lcov_log
-    echo -e "${COL_YELLOW}Testing complete for package \"$pkgname\". Ran $num_tests tests.${COL_RESET}" |& tee -a $lcov_log
-  done
-     
-  echo "Collecting coverage results"  |& tee -a $lcov_log
-lcov -d  $DBT_AREA_ROOT --capture --output-file  $DBT_AREA_ROOT/dunedaq.info >>$lcov_log 2>&1 || \
-error "lcov -d  $DBT_AREA_ROOT --capture --output-file  $DBT_AREA_ROOT/dunedaq.info returned nonzero; exiting..."
-
-lcov -a dunedaq.base -a  $DBT_AREA_ROOT/dunedaq.info --output-file  $DBT_AREA_ROOT/dunedaq.total >>$lcov_log 2>&1 || \
-error "lcov -a dunedaq.base -a  $DBT_AREA_ROOT/dunedaq.info --output-file  $DBT_AREA_ROOT/dunedaq.total returned nonzero; exiting..."
-
-lcov --remove  $DBT_AREA_ROOT/dunedaq.total '*/products/*' '/usr/include/*' '/cvmfs/*' "$DBT_AREA_ROOT/build/*" "*/pybindsrc/*" --output-file  $DBT_AREA_ROOT/dunedaq.info.cleaned >>$lcov_log 2>&1 || \
-error "lcov --remove  $DBT_AREA_ROOT/dunedaq.total '*/products/*' '*/opt/spack/*' '/usr/include/*' '/cvmfs/*' "$DBT_AREA_ROOT/build/*" --output-file  $DBT_AREA_ROOT/dunedaq.info.cleaned returned nonzero; exiting..."
-
-  echo "Creationg HTML output"  |& tee -a $lcov_log
-genhtml --demangle-cpp -o  $DBT_AREA_ROOT/coverage  $DBT_AREA_ROOT/dunedaq.info.cleaned >>$lcov_log 2>&1 || \
-error "genhtml --demangle-cpp -o  $DBT_AREA_ROOT/coverage  $DBT_AREA_ROOT/dunedaq.info.cleaned returned nonzero; exiting..."
-#genhtml -o coverage dunedaq.info
-
-echo
-echo "Full LCOV output saved in $lcov_log"
-echo 
+echo "Script completed successfully. Results are in $output_dir"

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # DUNE DAQ Buildtools
 
-_This document was last edited Feb-8-2024_
+_This document was last edited Jan-30-2025_
 
 `daq-buildtools` is the toolset to simplify the development of DUNE DAQ packages. It provides environment and building utilities for the DAQ Suite.
 
@@ -234,6 +234,15 @@ This file is sourced whenever you run `dbt-workarea-env`, and it tells both the 
 * `$SPACK_RELEASES_DIR`: The base of the directory containing the DUNE DAQ software installations. 
 * `DBT_ROOT_WHEN_CREATED`: The directory containing the `env.sh` file which was sourced before this work area was first created
 * `LOCAL_SPACK_DIR`: If the `-s/--spack` was passed to `dbt-create` when the work area was built, this points to where the local Spack area is located
+
+### `dbt-lcov.sh`
+
+Strictly speaking, this script is more about finding info about your code than about your work area per se in that it determines what fraction of your lines of code and functions the unit tests in your work area's repos cover. This script wraps calls to our installed external [`lcov` package](https://github.com/linux-test-project/lcov). Assuming you've set up your work area's enviroment and are in its base, if you run
+```
+dbt-lcov.sh`
+```
+what will happen is that, if needed, the script will insert a few lines of CMake code into the `sourcecode/CMakeLists.txt` file which will ensure that when the repos are built the output will be instrumented in a manner `lcov` can use. It will then perform a clean build now that `sourcecode/CMakeLists.txt` has been modified, followed by a run of the unit tests. It will then output the results in a subdirectory called `./code_coverage_results`; in particular, `./code_coverage_results/html/index.html` is a webpage which will display the fractions mentioned above. 
+
 
 ### Useful Spack commands
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -237,11 +237,13 @@ This file is sourced whenever you run `dbt-workarea-env`, and it tells both the 
 
 ### `dbt-lcov.sh`
 
-Strictly speaking, this script is more about finding info about your code than about your work area per se in that it determines what fraction of your lines of code and functions the unit tests in your work area's repos cover. This script wraps calls to our installed external [`lcov` package](https://github.com/linux-test-project/lcov). Assuming you've set up your work area's enviroment and are in its base, if you run
+Strictly speaking, this script is more about finding info about your code than about your work area. It determines what fraction of your lines of code and functions the unit tests in your work area's repos cover. This script wraps calls to our installed external [`lcov` package](https://github.com/linux-test-project/lcov). Assuming you've set up your work area's enviroment and are in its base, if you run
 ```
-dbt-lcov.sh`
+dbt-lcov.sh
 ```
-what will happen is that, if needed, the script will insert a few lines of CMake code into the `sourcecode/CMakeLists.txt` file which will ensure that when the repos are built the output will be instrumented in a manner `lcov` can use. It will then perform a clean build now that `sourcecode/CMakeLists.txt` has been modified, followed by a run of the unit tests. It will then output the results in a subdirectory called `./code_coverage_results`; in particular, `./code_coverage_results/html/index.html` is a webpage which will display the fractions mentioned above. 
+what will happen is that, if it hasn't already been run, the script will insert a few lines of CMake code into the `sourcecode/CMakeLists.txt` file which will ensure that when the repos are built the output will be instrumented in a manner `lcov` can use. It will then perform a clean build now that `sourcecode/CMakeLists.txt` has been modified, followed by a run of the unit tests. It will then output the results in a subdirectory called `./code_coverage_results`; in particular, `./code_coverage_results/html/index.html` is a webpage which will display the fractions mentioned above. 
+
+Please note that due to the modification of `sourcecode/CMakeLists.txt`, you wouldn't want to use the code you build for normal running (e.g., for performance testing or data readout). Likely it's best to use a work area dedicated to code coverage study as opposed to other functions.  
 
 
 ### Useful Spack commands


### PR DESCRIPTION
This PR makes the `dbt-lcov.sh` script available for use; it's described in the documentation added on this feature branch, clickable [here](https://github.com/DUNE-DAQ/daq-buildtools/blob/johnfreeman/issue289_code_coverage/docs/README.md#dbt-lcovsh)