### PR TITLE
Implement `--pytest` option to `dbt-build`

### DIFF
--- a/bin/dbt-build
+++ b/bin/dbt-build
@@ -23,6 +23,7 @@ import pathlib
 import re
 import sh
 import shutil
+import subprocess
 from shutil import rmtree, which
 from time import sleep
 import rich
@@ -451,7 +452,7 @@ if run_pytests:
         pytest_package_list = sh.find("-L . -mindepth 1 -maxdepth 1 -type d -not -name .pytest_cache".split()).strip().split()
         print('Package list:', pytest_package_list)
     else:
-        pytest_package_list = [package_to_test]
+        pytest_package_list = [package_to_pytest]
 
     # Tests that still need porting from v4 to v5
     ignore_args = """--ignore trigger/integtest/td_leakage_between_runs_test.py 
@@ -459,15 +460,35 @@ if run_pytests:
     print('ignore_args:', ignore_args)
 
     for package in pytest_package_list:
-        capture_args = f"-v -s --junit-xml=pytest_{package}_results.xml".split()
-        pytest_args = capture_args + [package] + ignore_args
-        print('pytest_args:', pytest_args)
-        if pytest_args:
-            sh.pytest(*pytest_args, _out=sys.stdout, _err=sys.stderr)
-        else:
-            print("No packages found for pytest.")
+        package_has_tests = sh.find(f"-L {package}/ -name integtest -type d".split()).strip().split()
+        if not package_has_tests:
+            print(f"Package {package} does not have any pytest tests in its integtest/ directory. Skipping...")
+            continue
+        package_tests = sh.find(f"-L {package}/integtest -name *_test.py -type f".split()).strip().split()
+        # Example: Tests for ./dfmodules: ['./dfmodules/integtest/disabled_output_test.py', './dfmodules/integtest/insufficient_disk_space_test.py', './dfmodules/integtest/large_trigger_record_test.py', './dfmodules/integtest/multi_output_file_test.py']
 
-    rich.print(f"[yellow]Pytests complete for \"{package}\".[/yellow]")
+        print(f'Tests for {package}: {package_tests}')
+        for test in package_tests:
+            #capture_args = f"-v -s --junit-xml={pytest_log_dir}/{package}_{test}_results.xml".split()
+            print(f'--------{test}---------')
+            capture_args = f"--junit-xml={pytest_log_dir}/{package}_{test}_results.xml".split()
+            pytest_args = capture_args + [test] + ignore_args
+            print('pytest_args:', pytest_args)
+            with open(f"{pytest_log_dir}/{package}_pytest.log", "w") as log:
+                process = subprocess.Popen(
+                    ["pytest", package] + capture_args + ignore_args, 
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                    text=True,
+                    bufsize=1,
+                    universal_newlines=True)
+                for line in process.stdout:
+                    print(line, end="")
+                    log.write(line)
+                    log.flush()
+
+                process.wait()
+                exit_code = process.returncode
 
 if args.lint:
     os.chdir(BASEDIR)

--- a/bin/dbt-build
+++ b/bin/dbt-build
@@ -441,16 +441,33 @@ RUNNING UNIT TESTS IN {unittestdir}
 if run_pytests:
     datestring = re.sub("[: ]+", "_", sh.date().strip())
 
-    test_log_dir = f"{LOGDIR}/unit_tests_{datestring}"
-    test_log_summary = f"{test_log_dir}/unit_test_summary.log"
-    os.mkdir(test_log_dir)
+    pytest_log_dir = f"{LOGDIR}/pytest_tests_{datestring}"
+    pytest_log_summary = f"{pytest_log_dir}/pytest_summary.log"
+    os.mkdir(pytest_log_dir)
 
-    os.chdir(BUILDDIR)
+    os.chdir(SRCDIR)
 
     if args.pytest == "all":
-        package_list = sh.find("-L . -mindepth 1 -maxdepth 1 -type d -not -name CMakeFiles").strip().split()
+        pytest_package_list = sh.find("-L . -mindepth 1 -maxdepth 1 -type d -not -name .pytest_cache".split()).strip().split()
+        print('Package list:', pytest_package_list)
     else:
-        package_list = [package_to_test]
+        pytest_package_list = [package_to_test]
+
+    # Tests that still need porting from v4 to v5
+    ignore_args = """--ignore trigger/integtest/td_leakage_between_runs_test.py 
+                     --ignore "hsilibs/integtest/iceberg_real_hsi_test.py""".split()
+    print('ignore_args:', ignore_args)
+
+    for package in pytest_package_list:
+        capture_args = f"-v -s --junit-xml=pytest_{package}_results.xml".split()
+        pytest_args = capture_args + [package] + ignore_args
+        print('pytest_args:', pytest_args)
+        if pytest_args:
+            sh.pytest(*pytest_args, _out=sys.stdout, _err=sys.stderr)
+        else:
+            print("No packages found for pytest.")
+
+    rich.print(f"[yellow]Pytests complete for \"{package}\".[/yellow]")
 
 if args.lint:
     os.chdir(BASEDIR)
@@ -529,6 +546,14 @@ Detailed unit test results are saved in the following directory:
 {test_log_dir}
 """
 
+pytestinfo = ""
+if run_pytests:
+    pytestinfo=f"""
+Pytest summary can be found in {pytest_log_summary}.
+Detailed pytest results are saved in the following directory:
+{pytest_log_dir}
+"""
+
 lintinfo = ""
 if args.lint and not code_to_lint_is_a_file:    
     lintinfo=f"""
@@ -543,6 +568,7 @@ build details you can either scroll up or run the following:
 less -R {build_log}
 
 {testinfo}
+{pytestinfo}
 {lintinfo}
 """)
 

--- a/bin/dbt-build
+++ b/bin/dbt-build
@@ -44,12 +44,13 @@ usage_blurb=f"""
 Usage
 -----
 
-      {os.path.basename(__file__)} [-c/--clean] [-d/--debug] [-j<n>/--jobs <number parallel build jobs>] [--unittest (<optional package name>)] [--lint (<optional package name|optional file name>)] [-v/--cpp-verbose] [-h/--help]
+      {os.path.basename(__file__)} [-c/--clean] [-d/--debug] [-j<n>/--jobs <number parallel build jobs>] [--unittest (<optional package name>)] [--pytest <optional package name>] [--lint (<optional package name|optional file name>)] [-v/--cpp-verbose] [-h/--help]
 
         -c/--clean means the contents of ./build are deleted and CMake's config+generate+build stages are run
         -d/--debug means you want to build your software with optimizations off and debugging info on
         -j/--jobs means you want to specify the number of jobs used by cmake to build the project
         --unittest means that unit test executables found in ./build/<optional package name>/unittest are run, or all unit tests in ./build/*/unittest are run if no package name is provided
+        --pytest means that pytest tests found in ./build/<optional package name>/integtest are run, or all pytest tests in ./build/*/integtest are run if no package name is provided
         --lint means you check for deviations in ./sourcecode/<optional package name> from the DUNE style guide, https://dune-daq-sw.readthedocs.io/en/latest/packages/styleguide/, or deviations in all local repos if no package name is provided. You can also pass the name of an individual file. 
         -v/--cpp-verbose means that you want verbose output from the compiler
         --cmake-msg-lvl setting "CMAKE_MESSAGE_LOG_LEVEL", default is "NOTICE", choices are ERROR|WARNING|NOTICE|STATUS|VERBOSE|DEBUG|TRACE.
@@ -83,6 +84,7 @@ parser.add_argument("-d", "--debug", action="store_true", dest='debug_build', he
 parser.add_argument("-v", "--cpp-verbose", action="store_true", dest='cpp_verbose', help=argparse.SUPPRESS)
 parser.add_argument("-j", "--jobs", action='store', type=int, dest='n_jobs', help=argparse.SUPPRESS)
 parser.add_argument("--unittest", nargs="?", const="all", help=argparse.SUPPRESS)
+parser.add_argument("--pytest", nargs="?", const="all", help=argparse.SUPPRESS)
 parser.add_argument("--lint", nargs="?", const="all", help=argparse.SUPPRESS)
 parser.add_argument("--cmake-msg-lvl", dest="cmake_msg_lvl", help=argparse.SUPPRESS)
 parser.add_argument("--optimize-flag", dest="optimize_flag", help=argparse.SUPPRESS)
@@ -110,6 +112,12 @@ if args.unittest:
     run_tests=True
     if args.unittest != "all":
         package_to_test = args.unittest
+
+run_pytests = False
+if args.pytest:
+    run_pytests=True
+    if args.pytest != "all":
+        package_to_pytest = args.pytest
 
 lint = False
 if args.lint:
@@ -429,6 +437,20 @@ RUNNING UNIT TESTS IN {unittestdir}
 
             rich.print(f"[yellow]Testing complete for package \"{pkgname}\". Ran {num_unit_tests} unit test suites.[/yellow]")
             rich.print("")
+
+if run_pytests:
+    datestring = re.sub("[: ]+", "_", sh.date().strip())
+
+    test_log_dir = f"{LOGDIR}/unit_tests_{datestring}"
+    test_log_summary = f"{test_log_dir}/unit_test_summary.log"
+    os.mkdir(test_log_dir)
+
+    os.chdir(BUILDDIR)
+
+    if args.pytest == "all":
+        package_list = sh.find("-L . -mindepth 1 -maxdepth 1 -type d -not -name CMakeFiles").strip().split()
+    else:
+        package_list = [package_to_test]
 
 if args.lint:
     os.chdir(BASEDIR)

--- a/bin/dbt-build
+++ b/bin/dbt-build
@@ -442,40 +442,39 @@ RUNNING UNIT TESTS IN {unittestdir}
 if run_pytests:
     datestring = re.sub("[: ]+", "_", sh.date().strip())
 
-    pytest_log_dir = f"{LOGDIR}/pytest_tests_{datestring}"
-    pytest_log_summary = f"{pytest_log_dir}/pytest_summary.log"
-    os.mkdir(pytest_log_dir)
+    pytest_log_dir = pathlib.Path(LOGDIR)/f"pytest_tests_{datestring}"
+    pytest_log_summary = pytest_log_dir/"pytest_summary.log"
+    pytest_log_dir.mkdir(parents=True, exist_ok=True)
 
-    os.chdir(SRCDIR)
+    os.chdir(BASEDIR)
 
     if args.pytest == "all":
-        pytest_package_list = sh.find("-L . -mindepth 1 -maxdepth 1 -type d -not -name .pytest_cache".split()).strip().split()
+        pytest_package_list = [path for path in pathlib.Path('sourcecode').iterdir() 
+                               if path.is_dir() and path.name != '.pytest_cache']
     else:
-        pytest_package_list = [package_to_pytest]
+        pytest_package_list = [pathlib.Path(f'sourcecode/{package_to_pytest}')]
 
     # Optional tests to ignore, such as tests that still need porting from v4 to v5
     #ignore_args = """--ignore trigger/integtest/td_leakage_between_runs_test.py 
     #                 --ignore "hsilibs/integtest/iceberg_real_hsi_test.py""".split()
     ignore_args = []
 
-    for package in pytest_package_list:
-        package_has_tests = sh.find(f"-L {package}/ -name integtest -type d".split()).strip().split()
-        if not package_has_tests:
-            echo_no_pytest = f"-e \033[31mNo pytest tests found in the integtest/ directory for package {os.path.basename(package)} \033[0m"
-            pytee.run("echo", echo_no_pytest.split(), pytest_log_summary)
+    for package_path in pytest_package_list:
+        package = package_path.stem
+        if not (package_path/"integtest").is_dir():
+            pytee.run("echo", ["-e", f"\033[31mNo pytest tests found in {package}/integtest\033[0m"], pytest_log_summary)
             continue
         # Pytests should be stored in the integtest/ directory
-        package_pytests = sh.find(f"-L {package}/integtest -name *_test.py -type f".split()).strip().split()
+        package_pytests = package_path.glob('integtest/*_test.py')
 
-        for pytest in package_pytests:
-            pytest_name = os.path.basename(pytest.replace('.py', ''))
-            pytest_full_output_log = f"{pytest_log_dir}/{package}_{pytest_name}.log"
-            pytest_junit_xml_output = f"{pytest_log_dir}/{package}_{pytest_name}_results.xml"
-            capture_args = f"-v -s --junit-xml={pytest_junit_xml_output}".split()
-            pytest_args = capture_args + [pytest] + ignore_args
+        for pytest_path in package_pytests:
+            pytest_name = (pathlib.Path(pytest_path).stem).replace('.py', '')
+            pytest_full_output_log = pytest_log_dir / f"{package}_{pytest_name}.log"
+            pytest_junit_xml_output = pytest_log_dir / f"{package}_{pytest_name}_results.xml"
+            pytest_cmd = ["pytest", pytest_path, "-v", "-s", f"--junit-xml={pytest_junit_xml_output}"] + ignore_args
             with open(pytest_full_output_log, "w") as log:
                 process = subprocess.Popen(
-                    ["pytest", package] + capture_args + ignore_args, 
+                    pytest_cmd,
                     stdout=subprocess.PIPE,
                     stderr=subprocess.PIPE,
                     text=True,
@@ -488,21 +487,26 @@ if run_pytests:
 
                 process.wait()
                 exit_code = process.returncode
-                if exit_code != 0:
-                    echo_result = f"-e {package}.{pytest_name:.<70}FAILURE"
-                else:
-                    echo_result = f"-e {package}.{pytest_name:.<70}SUCCESS"
-                pytee.run("echo", echo_result.split(), pytest_log_summary)
+                result_message = f"-e {package}.{pytest_name:.<70}{'SUCCESS' if exit_code == 0 else 'FAILURE'}"
+                pytee.run("echo", result_message.split(), pytest_log_summary)
 
             rich.print(f"""[yellow]Test \"{pytest_name}\" complete for package \"{package}\". 
             The full pytest output can be found at {pytest_full_output_log}
             The junit xml file can be found at {pytest_junit_xml_output}[/yellow]""")
 
         # Remove __pycache__ directories
-        pycache_dir = sh.find('.', '-name', '__pycache__', '-type', 'd').strip().split()
-        if pycache_dir:
-            rich.print(f"[yellow] Removing __pycache__ directory from {pycache_dir}")
+        pycache_dir = package_path/'integtest/__pycache__'
+        if pycache_dir.is_dir():
+            rich.print(f"[yellow] Removing __pycache__ directory from {package_path/'integtest'}")
             sh.rm('-rf', pycache_dir)
+    # Move .pytest_cache directory to suppress build warnings
+    src_pytest_cache = pathlib.Path('sourcecode/.pytest_cache')
+    if src_pytest_cache.is_dir():
+        rich.print(f"[yellow] Moving {src_pytest_cache} to {BASEDIR}")
+        base_pytest_cache = pathlib.Path(f'{BASEDIR}/.pytest_cache')
+        if base_pytest_cache.is_dir():
+            sh.rm('-rf', base_pytest_cache)
+        src_pytest_cache.rename(base_pytest_cache)
 
 if args.lint:
     os.chdir(BASEDIR)

--- a/bin/dbt-build
+++ b/bin/dbt-build
@@ -471,7 +471,7 @@ if run_pytests:
             pytest_name = os.path.basename(pytest.replace('.py', ''))
             pytest_full_output_log = f"{pytest_log_dir}/{package}_{pytest_name}.log"
             pytest_junit_xml_output = f"{pytest_log_dir}/{package}_{pytest_name}_results.xml"
-            capture_args = f"--junit-xml={pytest_junit_xml_output}".split()
+            capture_args = f"-v -s --junit-xml={pytest_junit_xml_output}".split()
             pytest_args = capture_args + [pytest] + ignore_args
             with open(pytest_full_output_log, "w") as log:
                 process = subprocess.Popen(
@@ -497,6 +497,12 @@ if run_pytests:
             rich.print(f"""[yellow]Test \"{pytest_name}\" complete for package \"{package}\". 
             The full pytest output can be found at {pytest_full_output_log}
             The junit xml file can be found at {pytest_junit_xml_output}[/yellow]""")
+
+        # Remove __pycache__ directories
+        pycache_dir = sh.find('.', '-name', '__pycache__', '-type', 'd').strip().split()
+        if pycache_dir:
+            rich.print(f"[yellow] Removing __pycache__ directory from {pycache_dir}")
+            sh.rm('-rf', pycache_dir)
 
 if args.lint:
     os.chdir(BASEDIR)

--- a/bin/dbt-build
+++ b/bin/dbt-build
@@ -450,31 +450,30 @@ if run_pytests:
 
     if args.pytest == "all":
         pytest_package_list = sh.find("-L . -mindepth 1 -maxdepth 1 -type d -not -name .pytest_cache".split()).strip().split()
-        print('Package list:', pytest_package_list)
     else:
         pytest_package_list = [package_to_pytest]
 
-    # Tests that still need porting from v4 to v5
-    ignore_args = """--ignore trigger/integtest/td_leakage_between_runs_test.py 
-                     --ignore "hsilibs/integtest/iceberg_real_hsi_test.py""".split()
-    print('ignore_args:', ignore_args)
+    # Optional tests to ignore, such as tests that still need porting from v4 to v5
+    #ignore_args = """--ignore trigger/integtest/td_leakage_between_runs_test.py 
+    #                 --ignore "hsilibs/integtest/iceberg_real_hsi_test.py""".split()
+    ignore_args = []
 
     for package in pytest_package_list:
         package_has_tests = sh.find(f"-L {package}/ -name integtest -type d".split()).strip().split()
         if not package_has_tests:
-            print(f"Package {package} does not have any pytest tests in its integtest/ directory. Skipping...")
+            echo_no_pytest = f"-e \033[31mNo pytest tests found in the integtest/ directory for package {os.path.basename(package)} \033[0m"
+            pytee.run("echo", echo_no_pytest.split(), pytest_log_summary)
             continue
-        package_tests = sh.find(f"-L {package}/integtest -name *_test.py -type f".split()).strip().split()
-        # Example: Tests for ./dfmodules: ['./dfmodules/integtest/disabled_output_test.py', './dfmodules/integtest/insufficient_disk_space_test.py', './dfmodules/integtest/large_trigger_record_test.py', './dfmodules/integtest/multi_output_file_test.py']
+        # Pytests should be stored in the integtest/ directory
+        package_pytests = sh.find(f"-L {package}/integtest -name *_test.py -type f".split()).strip().split()
 
-        print(f'Tests for {package}: {package_tests}')
-        for test in package_tests:
-            #capture_args = f"-v -s --junit-xml={pytest_log_dir}/{package}_{test}_results.xml".split()
-            print(f'--------{test}---------')
-            capture_args = f"--junit-xml={pytest_log_dir}/{package}_{test}_results.xml".split()
-            pytest_args = capture_args + [test] + ignore_args
-            print('pytest_args:', pytest_args)
-            with open(f"{pytest_log_dir}/{package}_pytest.log", "w") as log:
+        for pytest in package_pytests:
+            pytest_name = os.path.basename(pytest.replace('.py', ''))
+            pytest_full_output_log = f"{pytest_log_dir}/{package}_{pytest_name}.log"
+            pytest_junit_xml_output = f"{pytest_log_dir}/{package}_{pytest_name}_results.xml"
+            capture_args = f"--junit-xml={pytest_junit_xml_output}".split()
+            pytest_args = capture_args + [pytest] + ignore_args
+            with open(pytest_full_output_log, "w") as log:
                 process = subprocess.Popen(
                     ["pytest", package] + capture_args + ignore_args, 
                     stdout=subprocess.PIPE,
@@ -489,6 +488,15 @@ if run_pytests:
 
                 process.wait()
                 exit_code = process.returncode
+                if exit_code != 0:
+                    echo_result = f"-e {package}.{pytest_name:.<70}FAILURE"
+                else:
+                    echo_result = f"-e {package}.{pytest_name:.<70}SUCCESS"
+                pytee.run("echo", echo_result.split(), pytest_log_summary)
+
+            rich.print(f"""[yellow]Test \"{pytest_name}\" complete for package \"{package}\". 
+            The full pytest output can be found at {pytest_full_output_log}
+            The junit xml file can be found at {pytest_junit_xml_output}[/yellow]""")
 
 if args.lint:
     os.chdir(BASEDIR)


### PR DESCRIPTION
Addresses #295. Running `dbt-build --pytest` will scan the `$DBT_AREA_ROOT/sourcecode` directory for pytest modules stored in an `integtest` directory. Packages with tests stored elsewhere are not yet accounted for, but could be added in the future. `dbt-build --pytest <package>` is also supported. 

The pytest output is stored in both a log file and a junit xml file. The junit xml file will be parsed in an upcoming workflow for running pytests. There is also a summary file that shows which tests had one or more failures. 