### PR TITLE
Development area setup recipes

### DIFF
--- a/scripts/generate_dunedaq_setup_recipe.py
+++ b/scripts/generate_dunedaq_setup_recipe.py
@@ -5,6 +5,10 @@ import yaml
 import subprocess
 import click
 
+class CustomError(CustomError):
+    def format_message(self):
+        return f"🚨 ERROR: {self.message}"
+
 def run_git_cmd(repo_path,args,quiet_fail=False):
     return subprocess.check_output(['git', '-C', repo_path] + args,
                                    stderr=subprocess.DEVNULL if quiet_fail else None).decode().strip()
@@ -23,14 +27,16 @@ def validate_git_commit(repo_path, commit, repo_name):
     # 1. Check for uncommitted changes
     status = run_git_cmd(repo_path,['status', '--porcelain'])
     if status:
-        click.echo(f"Repository '{repo_name}' has uncommitted changes! Commit them before re-running.",
+        click.echo(f"🚨 ERROR: Repository '{repo_name}' has uncommitted changes! "
+                   "Commit them before re-running.",
                    err=True)
         return False
 
     # 2. Check if commit is reachable from a remote branch or tag
     branches = run_git_cmd(repo_path,['branch', '-r', '--contains', commit])
     if not any('origin/' in line for line in branches.splitlines()):
-        click.echo(f"Commit {commit[:7]} in repo '{repo_name}' is not pushed to origin. Push before re-running.",
+        click.echo(f"🚨 ERROR: Commit {commit[:7]} in repo '{repo_name}' is not pushed to origin. "
+                   "Push before re-running.",
                    err=True)
         return False
 
@@ -92,7 +98,8 @@ def get_repo_info(repo_path):
 
 @click.command()
 @click.argument('recipe_name')
-@click.option('--require-valid-refs',is_flag=True,help='Require all refs are valid (default False)')
+@click.option('--require-valid-refs',is_flag=True,
+              help='Require all refs are valid (default False)')
 def generate_dunedaq_setup_recipe(recipe_name,require_valid_refs):
     """Generate a DAQ workarea setup recipe based on the current source tree.
 
@@ -103,8 +110,8 @@ def generate_dunedaq_setup_recipe(recipe_name,require_valid_refs):
     daq_release = os.environ.get("DUNE_DAQ_BASE_RELEASE")
 
     if not daq_release:
-        raise click.ClickException("DUNE_DAQ_BASE_RELEASE not set in environment!"
-                                   "Setup dunedaq before running this script.")
+        raise CustomError("DUNE_DAQ_BASE_RELEASE not set in environment! "
+                          "Setup dunedaq before running this script.")
 
     sourcecode_dir = os.path.join(os.environ.get("DBT_AREA_ROOT"), "sourcecode")
 
@@ -121,11 +128,11 @@ def generate_dunedaq_setup_recipe(recipe_name,require_valid_refs):
 
     #check that all commits are ok, and optionally that all refs are ok
     if not all_commits_valid:
-        raise click.ClickException('ERROR: Not all commits are valid. Check errors and rerun.')
+        raise CustomError('Not all commits are valid. Check errors and rerun.')
 
     if require_valid_refs and not all_refs_valid:
-        raise click.ClickException('ERROR: Not all refs are valid, and you have requested they are.'
-                                   'Check errors/warnings and rerun.')
+        raise CustomError('Not all refs are valid, and you have requested they are. '
+                          'Check errors/warnings and rerun.')
 
     config = {
         'recipe_name': recipe_name,

--- a/scripts/generate_dunedaq_setup_recipe.py
+++ b/scripts/generate_dunedaq_setup_recipe.py
@@ -68,11 +68,11 @@ def get_repo_info(repo_path):
     #now, get the repo ref. Call it 'NONE' if unknown.
     try:
         # Try to get branch name
-        ref = run_git_cmd(['symbolic-ref', '--short', 'HEAD'],quiet_fail=True)
+        ref = run_git_cmd(repo_path,['symbolic-ref', '--short', 'HEAD'],quiet_fail=True)
     except subprocess.CalledProcessError:
         # If in detached HEAD, get current tag or commit hash
         try:
-            ref = run_git_cmd(['describe', '--tags'],quiet_fail=True)
+            ref = run_git_cmd(repo_path,['describe', '--tags'],quiet_fail=True)
         except subprocess.CalledProcessError:
             ref = None
 
@@ -91,7 +91,7 @@ def get_repo_info(repo_path):
     }
 
 @click.command()
-@click.argument('recipe_name',help='Name to give to this recipe (output will be <recipe_name>.yaml)')
+@click.argument('recipe_name')
 @click.option('--require-valid-refs',is_flag=True,help='Require all refs are valid (default False)')
 def generate_dunedaq_setup_recipe(recipe_name,require_valid_refs):
     """Generate a DAQ workarea setup recipe based on the current source tree.

--- a/scripts/generate_dunedaq_setup_recipe.py
+++ b/scripts/generate_dunedaq_setup_recipe.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+
+import os
+import yaml
+import subprocess
+import click
+
+def run_git_cmd(repo_path,args,quiet_fail=False):
+    return subprocess.check_output(['git', '-C', repo_path] + args,
+                                   stderr=subprocess.DEVNULL if quiet_fail else None).decode().strip()
+
+def get_dunedaq_release_type(release_name):
+    if 'rc' in release_name:
+        return 'candidate'
+    elif release_name.startswith('N'):
+        return 'nightly'
+    else:
+        #return 'frozen'
+        return 'static'
+
+def validate_git_commit(repo_path, commit, repo_name):
+
+    # 1. Check for uncommitted changes
+    status = run_git_cmd(repo_path,['status', '--porcelain'])
+    if status:
+        click.echo(f"Repository '{repo_name}' has uncommitted changes! Commit them before re-running.",
+                   err=True)
+        return False
+
+    # 2. Check if commit is reachable from a remote branch or tag
+    branches = run_git_cmd(repo_path,['branch', '-r', '--contains', commit])
+    if not any('origin/' in line for line in branches.splitlines()):
+        click.echo(f"Commit {commit[:7]} in repo '{repo_name}' is not pushed to origin. Push before re-running.",
+                   err=True)
+        return False
+
+    #if neither of those, commit is ok
+    return True
+
+def validate_git_ref(repo_path, ref, repo_name):
+
+    # Check if ref (branch or tag) exists on origin
+    # Note that this should only produce a warning if not available
+    ref_exists = False
+
+    branch_check = run_git_cmd(repo_path,['ls-remote', '--heads', 'origin', ref])
+    if branch_check:
+        ref_exists = True
+
+    if not ref_exists:
+        tag_check = run_git_cmd(repo_path,['ls-remote', '--tags', 'origin', ref])
+        if tag_check:
+            ref_exists = True
+
+    if not ref_exists:
+        click.echo(f"⚠️  WARNING: Ref '{ref}' in repo '{repo_name}' does not exist on origin."
+                    "Push reference, or only commit hashes will work.")
+
+    return ref_exists
+
+def get_repo_info(repo_path):
+
+    #get the repo name, and the url
+    name = os.path.basename(repo_path)
+    url = f'https://github.com/DUNE-DAQ/{name}.git'
+    #url = run_git_cmd(['config', '--get', 'remote.origin.url'])
+
+    #now, get the repo ref. Call it 'NONE' if unknown.
+    try:
+        # Try to get branch name
+        ref = run_git_cmd(['symbolic-ref', '--short', 'HEAD'],quiet_fail=True)
+    except subprocess.CalledProcessError:
+        # If in detached HEAD, get current tag or commit hash
+        try:
+            ref = run_git_cmd(['describe', '--tags'],quiet_fail=True)
+        except subprocess.CalledProcessError:
+            ref = None
+
+    commit = run_git_cmd(repo_path,['rev-parse', 'HEAD'])
+
+    ref_valid = validate_git_ref(repo_path,ref,name) if ref else False
+    commit_valid = validate_git_commit(repo_path,commit,name)
+
+    return {
+        'name': name,
+        'url': url,
+        'ref': ref,
+        'ref_valid': ref_valid,
+        'commit': commit,
+        'commit_valid': commit_valid
+    }
+
+@click.command()
+@click.argument('recipe_name',help='Name to give to this recipe (output will be <recipe_name>.yaml)')
+@click.option('--require-valid-refs',is_flag=True,help='Require all refs are valid (default False)')
+def generate_dunedaq_setup_recipe(recipe_name,require_valid_refs):
+    """Generate a DAQ workarea setup recipe based on the current source tree.
+
+    RECIPE_NAME is the base name for the output YAML file.
+    """
+
+    yaml_filename = f"{recipe_name}.yaml"
+    daq_release = os.environ.get("DUNE_DAQ_BASE_RELEASE")
+
+    if not daq_release:
+        raise click.ClickException("DUNE_DAQ_BASE_RELEASE not set in environment!"
+                                   "Setup dunedaq before running this script.")
+
+    sourcecode_dir = os.path.join(os.environ.get("DBT_AREA_ROOT"), "sourcecode")
+
+    repos = []
+    all_commits_valid = True
+    all_refs_valid = True
+
+    for entry in os.listdir(sourcecode_dir):
+        repo_path = os.path.join(sourcecode_dir, entry)
+        if os.path.isdir(repo_path) and os.path.isdir(os.path.join(repo_path, '.git')):
+            repos.append(get_repo_info(repo_path))
+            if not repos[-1]['commit_valid']: all_commits_valid = False
+            if not repos[-1]['ref_valid']: all_refs_valid = False
+
+    #check that all commits are ok, and optionally that all refs are ok
+    if not all_commits_valid:
+        raise click.ClickException('ERROR: Not all commits are valid. Check errors and rerun.')
+
+    if require_valid_refs and not all_refs_valid:
+        raise click.ClickException('ERROR: Not all refs are valid, and you have requested they are.'
+                                   'Check errors/warnings and rerun.')
+
+    config = {
+        'recipe_name': recipe_name,
+        'daq_release': daq_release,
+        'daq_release_type': get_dunedaq_release_type(daq_release),
+        'repos': repos
+    }
+
+    with open(yaml_filename, 'w') as f:
+        yaml.dump(config, f, sort_keys=False)
+
+    click.echo(f"Wrote setup recipe to {yaml_filename}")
+
+if __name__ == '__main__':
+    generate_dunedaq_setup_recipe()

--- a/scripts/generate_dunedaq_setup_recipe.py
+++ b/scripts/generate_dunedaq_setup_recipe.py
@@ -5,7 +5,7 @@ import yaml
 import subprocess
 import click
 
-class CustomError(CustomError):
+class CustomError(click.ClickException):
     def format_message(self):
         return f"🚨 ERROR: {self.message}"
 
@@ -19,8 +19,8 @@ def get_dunedaq_release_type(release_name):
     elif release_name.startswith('N'):
         return 'nightly'
     else:
-        #return 'frozen'
-        return 'static'
+        return 'frozen' #use frozen for now, for better backwards compatibility
+        #return 'static'
 
 def validate_git_commit(repo_path, commit, repo_name):
 

--- a/scripts/setup_dunedaq_from_recipe.py
+++ b/scripts/setup_dunedaq_from_recipe.py
@@ -8,7 +8,7 @@ from datetime import datetime
 import urllib.request
 import tempfile
 
-class CustomError(CustomError):
+class CustomError(click.ClickException):
     def format_message(self):
         return f"🚨 ERROR: {self.message}"
 
@@ -64,7 +64,7 @@ def setup_dunedaq_from_recipe(recipe_source, use_ref, build, workarea_name):
     if not all_commits_valid:
         raise CustomError('Not all commits are valid. Check errors and rerun.')
     if not all_refs_valid and use_ref:
-        raise CustomError('Not all refs and you have requested to use them. '
+        raise CustomError('Not all refs are valid and you have requested to use them. '
                           'Check errors and rerun, or rerun without "--use-ref" option.')
 
     #now create a workarea

--- a/scripts/setup_dunedaq_from_recipe.py
+++ b/scripts/setup_dunedaq_from_recipe.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+
+import os
+import subprocess
+import yaml
+import click
+from datetime import datetime
+import urllib.request
+import tempfile
+
+@click.command()
+@click.argument('recipe_source')
+@click.option('--use-ref', is_flag=True, help='Use the ref (branch or tag) instead of the exact commit hash')
+@click.option('--build', is_flag=True, help='Also build the local area after creating it.')
+@click.option('--workarea-name',
+              help='Optional name for workarea to create (default: testarea_<recipe_name>_<timestamp>)')
+def setup_dunedaq_from_recipe(recipe_source, use_ref, build, workarea_name):
+    """Set up a DAQ workarea based on a saved configuration file or a URL"""
+
+    is_url = recipe_source.startswith("http://") or recipe_source.startswith("https://")
+    
+    if is_url:
+        click.echo(f"Downloading config from: {recipe_source}")
+        with urllib.request.urlopen(recipe_source) as response:
+            content = response.read()
+        tmp_file = tempfile.NamedTemporaryFile(delete=False)
+        with open(tmp_file.name, "wb") as f:
+            f.write(content)
+        recipe_file = tmp_file.name
+    else:
+        recipe_file = os.path.abspath(recipe_source)
+        if not os.path.exists(recipe_file):
+            raise click.ClickException(f"Config file {recipe_file} not found.")
+        
+    with open(recipe_file) as f:
+        recipe = yaml.safe_load(f)
+
+    daq_release = recipe['daq_release']
+    daq_release_type = recipe['daq_release_type']
+    recipe_name = recipe['recipe_name']
+    repos = recipe['repos']
+
+    #before doing anything, first check that the commits or refs were valid at creation
+    all_commits_valid = True
+    all_refs_valid = True
+    for repo in repos:
+        name = repo['name']
+        ref = repo['ref']
+        ref_valid = repo['ref_valid']
+        commit = repo['commit']
+        commit_valid = repo['commit_valid']
+
+        if not commit_valid:
+            click.echo(f'ERROR: commit {commit} in repo {name} not valid. Check with recipe creator.',err=True)
+            all_commits_valid = False
+        if not ref_valid and use_ref:
+            click.echo(f'ERROR: ref {ref} in repo {name} not valid. Check with recipe creator.',err=True)
+            all_refs_valid = False
+
+    if not all_commits_valid:
+        raise click.ClickException('ERROR: Not all commits are valid. Check errors and rerun.')
+    if not all_refs_valid and use_ref:
+        raise click.ClickException('ERROR: Not all refs and you have requested to use them. '
+                                   'Check errors and rerun, or rerun without "--use-ref" option.')
+
+    #now create a workarea
+    timestamp = datetime.now().strftime('%d%b_%H%M')
+    workarea_name = workarea_name or f"testarea_{recipe_name}_{timestamp}"
+
+    click.echo(f"Creating workarea '{workarea_name}' with release '{daq_release}'...")
+
+    subprocess.run(['bash', '-c', f'''
+        dbt-create -b {daq_release_type} {daq_release} {workarea_name}
+    '''], check=True, executable='/bin/bash')
+
+    workarea_path = os.path.abspath(workarea_name)
+    
+    sourcecode_path = os.path.join(workarea_path, "sourcecode")
+    os.chdir(sourcecode_path)
+
+    #now loop over the repos in the recipe, clone and checkout what's needed
+    for repo in repos:
+        name = repo['name']
+        url = repo['url']
+        ref = repo['ref']
+        commit = repo['commit']
+
+        click.echo(f"\nCloning {name}...")
+        subprocess.run(['git', 'clone', url, name], check=True)
+
+        repo_path = os.path.join(sourcecode_path, name)
+        os.chdir(repo_path)
+
+        #fetch everything
+        subprocess.run(['git', 'fetch', '--all', '--tags'],
+                       check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        resolved=False
+
+        # Always check if the ref still points to the same commit
+
+        # Try to resolve ref via origin/<ref> (for branches), then <ref> for tags
+        for ref_candidate in [f'origin/{ref}', ref]:
+            try:
+                ref_commit = subprocess.check_output(['git', 'rev-list', '-n', '1', ref_candidate],
+                                                     stderr=subprocess.DEVNULL).decode().strip()
+                resolved = True
+                break
+            except subprocess.CalledProcessError:
+                continue
+            if resolved:
+                if ref_commit != commit:
+                    click.echo(f"  ⚠️  WARNING: ref '{ref}' now points to a different commit than recorded")
+                    click.echo(f"     current: {ref_commit}")
+                    click.echo(f"     saved:   {commit}")
+            else:
+                click.echo(f"  ⚠️  Could not resolve ref '{ref}' to check commit hash")
+
+        # Checkout based on selected mode
+        if use_ref:
+            if not resolved:
+                raise click.ClickException(f'ERROR: Unable to resolve {ref} in repo {name} and you have requested to use it. '
+                                           'Check errors, or rerun without "--use-ref" option.')
+            click.echo(f"  Checking out ref: {ref}")
+            subprocess.run(['git', 'checkout', ref], check=True)
+        else:
+            click.echo(f"  Checking out commit: {commit}")
+            subprocess.run(['git', 'checkout', commit], check=True)
+
+        os.chdir(sourcecode_path)
+
+    os.chdir(workarea_path)  # Back to workarea root
+
+    click.echo(f"\n ✅ Workarea '{workarea_path}' set up successfully.")
+
+    if build:
+        click.echo("\nSetting up environment and building...")
+        subprocess.run(['bash', '-c', f'''
+            cd {workarea_path} &&
+            source env.sh &&
+            dbt-build -j 12 &&
+            dbt-workarea-env
+        '''], check=True, executable='/bin/bash')
+
+        click.echo(f"\n ✅ Workarea '{workarea_path}' built up successfully.")
+
+if __name__ == '__main__':
+    setup_dunedaq_from_recipe()

--- a/scripts/setup_dunedaq_from_recipe.py
+++ b/scripts/setup_dunedaq_from_recipe.py
@@ -8,6 +8,10 @@ from datetime import datetime
 import urllib.request
 import tempfile
 
+class CustomError(CustomError):
+    def format_message(self):
+        return f"🚨 ERROR: {self.message}"
+
 @click.command()
 @click.argument('recipe_source')
 @click.option('--use-ref', is_flag=True, help='Use the ref (branch or tag) instead of the exact commit hash')
@@ -30,7 +34,7 @@ def setup_dunedaq_from_recipe(recipe_source, use_ref, build, workarea_name):
     else:
         recipe_file = os.path.abspath(recipe_source)
         if not os.path.exists(recipe_file):
-            raise click.ClickException(f"Config file {recipe_file} not found.")
+            raise CustomError(f"Config file {recipe_file} not found.")
         
     with open(recipe_file) as f:
         recipe = yaml.safe_load(f)
@@ -51,17 +55,17 @@ def setup_dunedaq_from_recipe(recipe_source, use_ref, build, workarea_name):
         commit_valid = repo['commit_valid']
 
         if not commit_valid:
-            click.echo(f'ERROR: commit {commit} in repo {name} not valid. Check with recipe creator.',err=True)
+            click.echo(f'🚨 ERROR: commit {commit} in repo {name} not valid. Check with recipe creator.',err=True)
             all_commits_valid = False
         if not ref_valid and use_ref:
-            click.echo(f'ERROR: ref {ref} in repo {name} not valid. Check with recipe creator.',err=True)
+            click.echo(f'🚨 ERROR: ref {ref} in repo {name} not valid. Check with recipe creator.',err=True)
             all_refs_valid = False
 
     if not all_commits_valid:
-        raise click.ClickException('ERROR: Not all commits are valid. Check errors and rerun.')
+        raise CustomError('Not all commits are valid. Check errors and rerun.')
     if not all_refs_valid and use_ref:
-        raise click.ClickException('ERROR: Not all refs and you have requested to use them. '
-                                   'Check errors and rerun, or rerun without "--use-ref" option.')
+        raise CustomError('Not all refs and you have requested to use them. '
+                          'Check errors and rerun, or rerun without "--use-ref" option.')
 
     #now create a workarea
     timestamp = datetime.now().strftime('%d%b_%H%M')
@@ -109,17 +113,17 @@ def setup_dunedaq_from_recipe(recipe_source, use_ref, build, workarea_name):
                 continue
             if resolved:
                 if ref_commit != commit:
-                    click.echo(f"  ⚠️  WARNING: ref '{ref}' now points to a different commit than recorded")
-                    click.echo(f"     current: {ref_commit}")
-                    click.echo(f"     saved:   {commit}")
+                    click.echo(f"⚠️ WARNING: ref '{ref}' now points to a different commit than recorded")
+                    click.echo(f"   current: {ref_commit}")
+                    click.echo(f"   saved:   {commit}")
             else:
-                click.echo(f"  ⚠️  Could not resolve ref '{ref}' to check commit hash")
+                click.echo(f"⚠️  WARNING: could not resolve ref '{ref}' to check commit hash")
 
         # Checkout based on selected mode
         if use_ref:
             if not resolved:
-                raise click.ClickException(f'ERROR: Unable to resolve {ref} in repo {name} and you have requested to use it. '
-                                           'Check errors, or rerun without "--use-ref" option.')
+                raise CustomError(f'Unable to resolve {ref} in repo {name} and you have requested to use it. '
+                                  'Check errors, or rerun without "--use-ref" option.')
             click.echo(f"  Checking out ref: {ref}")
             subprocess.run(['git', 'checkout', ref], check=True)
         else:


### PR DESCRIPTION
See further description in slides here: https://indico.fnal.gov/event/69423/contributions/315350/attachments/187641/258772/devarea_setup_tools.pdf

This PR adds two new scripts to assist in reproducing development areas, particularly for the case of replication for testing.

- generate_dunedaq_setup_recipe.py
  - From within a setup work area, will create a 'recipe' file (YAML formatted) to capture the release, repos pulled down, and references to branches/tags and commits used.
- setup_dunedaq_from_recipe.py
  - Takes the recipe file produced from the above, and creates a work area with the right dunedaq version and repos w/ branches and tags or commits checked out.