### PR TITLE
JCF: in light of Issue #307, where SPACK_DISABLE_LOCAL_CONFIG is set …

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -6,7 +6,7 @@ _This document was last edited May-28-2025_
 
 ## System requirements
 
-To get set up, you'll need access to the cvmfs areas `/cvmfs/dunedaq.opensciencegrid.org` and `/cvmfs/dunedaq-development.opensciencegrid.org`. This is the case, e.g., on the np04 cluster at CERN. By default, the environment variable `SPACK_DISABLE_LOCAL_CONFIG` is set to `true`, which allows spack to skip user configurations found under `~/.spack`. In rare cases, if you want spack to pick up your local configurations, you can unset this environment variable by issuing `unset SPACK_DISABLE_LOCAL_CONFIG`. However, the recommended way of using customized spack configrations is via the use of a workarea with a local spack instance. Customizations to spack configurations can be directly put into that local instance. More details about how to create a workarea with a spack instance can be found in the "[Advanced dbt-create options section](#Advanced dbt-create options)" on this page. 
+To get set up, you'll need access to the cvmfs areas `/cvmfs/dunedaq.opensciencegrid.org` and `/cvmfs/dunedaq-development.opensciencegrid.org`. This is the case, e.g., on the np04 cluster at CERN. 
 
 <a name="Setup_of_daq-buildtools"></a>
 ## Setup of `daq-buildtools`

--- a/scripts/dbt-setup-constants.sh
+++ b/scripts/dbt-setup-constants.sh
@@ -1,7 +1,6 @@
 DBT_VENV=".venv"
 DBT_VENV_PROMPT="dbt"
 DBT_AREA_FILE="dbt-workarea-constants.sh"
-DISABLE_USER_SPACK_CONFIG="true"
 
 PROD_BASEPATH="/cvmfs/dunedaq.opensciencegrid.org/spack/releases"
 NIGHTLY_BASEPATH="/cvmfs/dunedaq-development.opensciencegrid.org/nightly"

--- a/scripts/dbt-setup-release.sh
+++ b/scripts/dbt-setup-release.sh
@@ -83,7 +83,6 @@ fi
 ARGS=("$@")
 
 source ${HERE}/dbt-setup-tools.sh
-export SPACK_DISABLE_LOCAL_CONFIG=${DISABLE_USER_SPACK_CONFIG}
 
 if [[ ! -e $SPACK_RELEASES_DIR ]]; then
     error "Directory \"$SPACK_RELEASES_DIR\" does not appear to exist; exiting..."

--- a/scripts/dbt-workarea-env.sh
+++ b/scripts/dbt-workarea-env.sh
@@ -45,7 +45,6 @@ done
 source ${HERE}/dbt-setup-tools.sh
 
 export DBT_AREA_ROOT=$(find_work_area)
-export SPACK_DISABLE_LOCAL_CONFIG=${DISABLE_USER_SPACK_CONFIG}
 
 if [[ -z $DBT_AREA_ROOT ]]; then
     error "Expected work area directory not found via call to find_work_area. Returning..."

--- a/scripts/dbt_create.py
+++ b/scripts/dbt_create.py
@@ -188,10 +188,6 @@ if args.install_spack:
     # Avoid environment conflicts with local user spack directory
     os.environ["SPACK_DISABLE_LOCAL_CONFIG"] = "true"
     os.environ["SPACK_USER_CACHE_PATH"] = f"{TARGETDIR}/.spack"
-    user_spack_dir = f'{os.environ["HOME"]}/.spack'
-    if os.path.exists(user_spack_dir):
-        print(f'WARNING A spack directory already exists at {user_spack_dir}.')
-        print(f'        This may cause environment conflicts with {TARGETDIR}/.spack')
     os.environ["LOCAL_SPACK_DIR"] = f"{TARGETDIR}/.spack"
     workarea_constants_file_contents += f"""export LOCAL_SPACK_DIR="{os.environ["LOCAL_SPACK_DIR"]}"
 """

--- a/scripts/dbt_setup_constants.py
+++ b/scripts/dbt_setup_constants.py
@@ -1,6 +1,5 @@
 DBT_VENV=".venv"
 DBT_AREA_FILE="dbt-workarea-constants.sh"
-DISABLE_USER_SPACK_CONFIG="true"
 
 PROD_BASEPATH="/cvmfs/dunedaq.opensciencegrid.org/spack/releases"
 NIGHTLY_BASEPATH="/cvmfs/dunedaq-development.opensciencegrid.org/nightly"


### PR DESCRIPTION
…whenever the daq-buildtools environment is set, disable the redundant logic of using a hardwired $DISABLE_USER_SPACK_CONFIG value to set SPACK_DISABLE_LOCAL_CONFIG