### PR TITLE
JCF: ensure that for bespoke builds (i.e., ones which don't begin wit…

### DIFF
--- a/scripts/dbt_setup_tools.py
+++ b/scripts/dbt_setup_tools.py
@@ -34,7 +34,7 @@ def find_work_area():
 def list_releases(release_basepath):
 
     versions = []
-    base_release_regex_signifiers = ["^dunedaq-", "^NB", "^rc-", "^coredaq-"]
+    base_release_regex_signifiers = ["^dunedaq-", "^NB", "B_", "^rc-", "^coredaq-"]
 
     origdir=os.getcwd()
     os.chdir(f"{release_basepath}")


### PR DESCRIPTION
…h N for Nightly) their base releases don't get listed when "dbt-create -n -l" is called