### PR TITLE
JCF: Issue #314: (further) deprecate dbt-unittest-summary.sh and put …

### DIFF
--- a/bin/dbt-build
+++ b/bin/dbt-build
@@ -376,6 +376,7 @@ for pkg in get_package_list(BUILDDIR):
 with open(f"{INSTALLDIR}/build_summary_info.json", 'w') as sbi_f:
     json.dump( summary_build_info, sbi_f, sort_keys=True, indent=4 )
 
+unittest_overviews = []
 if run_tests:
     stringio_obj5 = io.StringIO()
     sh.date(_out=stringio_obj5)
@@ -424,6 +425,8 @@ RUNNING UNIT TESTS IN {unittestdir}
                 if which(unittest_path, mode=os.X_OK) is not None:
                     pytee.run("echo", "-e Start of unit test suite {}".format(unittest).split(), test_log)
                     retval = pytee.run(unittest_path, "", test_log)
+
+                    unittest_overviews.append( (unittest_path, retval) )
                     ## Generate test_log_summary now
                     f_test_log = open(test_log, 'r')
                     test_result = re.findall(r'\*\*\* (No errors detected)', f_test_log.read())
@@ -437,7 +440,7 @@ RUNNING UNIT TESTS IN {unittestdir}
                     num_unit_tests += 1
 
             rich.print(f"[yellow]Testing complete for package \"{pkgname}\". Ran {num_unit_tests} unit test suites.[/yellow]")
-            rich.print("")
+            rich.print("\n")
 
 if run_integtests:
     datestring = re.sub("[: ]+", "_", sh.date().strip())
@@ -599,6 +602,20 @@ if args.lint and not code_to_lint_is_a_file:
 Automated code linting results can be found in the following directory:
 {lint_log_dir}.
 """
+
+# Recreate the output of the old dbt-unittest-summary.sh script
+
+if len(unittest_overviews) > 0:
+   rich.print("\n\n")
+   rich.print(f"[yellow]###########################SUMMARY OF UNIT TESTS##############################[/yellow]")
+
+for (path, retval) in unittest_overviews:
+   print(f"{path:.<120}", end = "")
+   if retval == 0:
+      rich.print('[green]SUCCESS[/green]')
+   else:
+      rich.print('[red]FAILURE[/red]')
+      rich.print("\n")
 
 rich.print(f"""
 This script is ending normally. This implies your code successfully compiled; to see

--- a/bin/dbt-build
+++ b/bin/dbt-build
@@ -615,8 +615,8 @@ for (path, retval) in unittest_overviews:
       rich.print('[green]SUCCESS[/green]')
    else:
       rich.print('[red]FAILURE[/red]')
-      rich.print("\n")
 
+rich.print("\n")
 rich.print(f"""
 This script is ending normally. This implies your code successfully compiled; to see
 build details you can either scroll up or run the following:

--- a/bin/dbt-unittest-summary.sh
+++ b/bin/dbt-unittest-summary.sh
@@ -1,61 +1,10 @@
 
-COL_RESET="\e[0m"
-COL_RED="\e[1;31m"
-COL_GREEN="\e[1;32m"
 
-source ${DBT_ROOT}/scripts/dbt-setup-tools.sh
-LOGDIR=${DBT_AREA_ROOT}/log
-test_log=$LOGDIR/unit_tests_$( date | sed -r 's/[: ]+/_/g' ).log
+cat<<EOF
 
-function echo_success() {
-  echo -e "${COL_GREEN}SUCCESS${COL_RESET}"
-}
+This script has been deprecated. In order to see a summary of the unit 
+tests for the repositories in this work area, simply scroll to the bottom
+of the output of "dbt-build --unittest"
 
-function echo_failure() {
-  echo -e "${COL_RED}FAILED${COL_RESET}"
-}
+EOF
 
-function echo_dots() {
-  ndots=$1
-  ii=0
-  while [ $ii -lt $ndots ];do
-    echo -n "."
-    ii=$(($ii + 1))
-  done
-}
-
-function check_unit_tests() {
-  dbt-build >/dev/null 2>&1 || error "DAQ build FAILED, exiting"
-  pushd $DBT_AREA_ROOT/build >/dev/null
-  echo
-  echo
-  package_list=$( find -L . -mindepth 1 -maxdepth 1 -type d -not -name CMakeFiles )
-  tests=
-  for pkgname in $package_list ; do
-    pkgtests=`find $pkgname/unittest -type f -exec readlink -f {} \; 2>/dev/null`
-    if [ ${#pkgtests} -gt 0 ]; then
-      tests="${tests} ${pkgtests}"
-    fi
-  done
-
-  maxwidth=0
-  for unittest in $tests;do
-    if [ ${#unittest} -gt $maxwidth ]; then
-      maxwidth=${#unittest}
-    fi
-  done
-
-  for unittest in $tests;do 
-    echo -n "$unittest"
-
-    echo_dots $((${maxwidth} - ${#unittest}+2))
-
-    $unittest >>$test_log 2>&1 && echo_success || echo_failure
-  done
-  popd >/dev/null
-     
-  echo
-  echo "Test results are saved in $test_log"
-  echo
-}
-check_unit_tests


### PR DESCRIPTION
…its output at the bottom of dbt-build --unittest