### PR TITLE
JCF: Issue #322: allow incremental builds if it's not established tha…

### DIFF
--- a/bin/dbt-build
+++ b/bin/dbt-build
@@ -115,11 +115,12 @@ you haven't requested sanitization for this build, so you also need to
 supply "--clean" to force a ground-up rebuild. Exiting...
 """)
       else:
-         if not "DBT_SANITIZE" in inf.read():
+         if not f"DBT_SANITIZE:UNINITIALIZED={args.sanitize}" in inf.read():
             error(f"""
 You've passed a \"--sanitize {args.sanitize}\" argument to this script,
 but you also need to supply "--clean" to force a ground-up rebuild since
-it appears a previous build was performed without sanitization. Exiting...
+it appears a previous build was performed either without sanitization,
+or with a different form of sanitization. Exiting...
 """)
 
 if args.optimize_flag:

--- a/bin/dbt-build
+++ b/bin/dbt-build
@@ -105,10 +105,21 @@ script; this is not allowed as they both try to set the optimization level of
 a gcc build
 """)
 
-if args.sanitize:
-   if not args.clean_build:
-      error(f"""
-You've passed a \"--sanitize {args.sanitize}\" argument to this script, but you also need to supply "--clean" to force a ground-up rebuild
+if not args.clean_build and os.path.exists(f"{BUILDDIR}/CMakeCache.txt"):
+   with open(f"{BUILDDIR}/CMakeCache.txt") as inf:
+      if not args.sanitize:
+         if "DBT_SANITIZE" in inf.read():
+            error(f"""
+It appears a previous build was performed with gcc sanitization on; however,
+you haven't requested sanitization for this build, so you also need to
+supply "--clean" to force a ground-up rebuild. Exiting...
+""")
+      else:
+         if not "DBT_SANITIZE" in inf.read():
+            error(f"""
+You've passed a \"--sanitize {args.sanitize}\" argument to this script,
+but you also need to supply "--clean" to force a ground-up rebuild since
+it appears a previous build was performed without sanitization. Exiting...
 """)
 
 if args.optimize_flag:


### PR DESCRIPTION
…t a previous build didn't use a different sanitization regime

# Description

Enable incremental builds using sanitization assuming the previous build wasn't non-sanitized
See issue #322 for details

In my original PR introducing a code sanitization pass through to `dbt-build`, https://github.com/DUNE-DAQ/daq-buildtools/pull/320, I added a constraint that you could only perform sanitization with a `--clean` build. Eric pointed out that this is overly restrictive, so this PR now allows for an incremental sanitization build as long as the previous build wasn't non-sanitized. Note that I also added the mirror image logic, to wit: if a user tries a non-sanitized, incremental build but sanitization was inserted in the previous build, this is an error. 

Should be easy to get into `fddaq-v5.5.0`. 

To test, try incremental builds (i.e., leave out the `--clean` option) with and without sanitization on top of previous builds with and without sanitization, and check that the behavior is what you want. 


## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking change that improves code/performance)
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] Breaking change (whatever its nature)

## Testing checklist

- [ ] Unit tests pass (e.g. `dbt-build --unittest`)
- [ ] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [ ] Full set of integration tests pass (`daqsystemtest_integtest_bundle.sh`)
- [ ] Python tests pass if applicable (e.g. `python -m pytest`)
- [ ] Pre-commit hooks run successfully if applicable (e.g. `pre-commit run --all-files`)

N/A

_Comments here on the testing_

## Further checks

- [ ] Code is commented where needed, particularly in hard-to-understand areas
- [ ] Code style is correct (`dbt-build --lint`, and/or see https://dune-daq-sw.readthedocs.io/en/latest/packages/styleguide/)
- [ ] If applicable, new tests have been added or an issue has been opened to tackle that in the future.
  (Indicate issue here: # (issue))

