### PR TITLE
Add ANSI filter when redirecting log output files

### DIFF
--- a/bin/dbt-build
+++ b/bin/dbt-build
@@ -31,6 +31,8 @@ import json
 
 sys.path.append(f'{DBT_ROOT}/scripts')
 
+ansi_escape = re.compile(r'\x1b\[[0-9;]*m')
+
 from dbt_setup_tools import error, find_work_area, get_time
 import pytee
 
@@ -509,7 +511,8 @@ if run_integtests:
                     universal_newlines=True)
                 for line in process.stdout:
                     print(line, end="")
-                    log.write(line)
+                    clean_line = ansi_escape.sub('', line)
+                    log.write(clean_line)
                     log.flush()
 
                 process.wait()


### PR DESCRIPTION
# Description

**Depends on the following** 
https://github.com/DUNE-DAQ/daqpytools/pull/32
https://github.com/DUNE-DAQ/drunc/pull/690

**See also the following**
https://github.com/DUNE-DAQ/daqsystemtest/pull/268
https://github.com/DUNE-DAQ/dfmodules/pull/461

The above repositories add daqpytools into drunc, which has good quality of life improvements, including rich handling and colors in the terminal outputs. 
However, the int tests `tee` the terminal output directly into the log files. This has the unfortunate side effect that the ANSI characters used to define the colors are also copied into the log texts, resulting in lines such as the following:
```
[2;34m[2025/11/17 14:21:32 UTC][0m [1;32mINFO      [0m [2;37mprocess_manager.py:116                  [0m [2;37mdrunc.process_manager                             [0m process_manager communicating through address [1;92m10.73.136.38[0m[1;32m:[0m[1;36m46575[0m
```

This PR modifies the `tee` command in the int tests to pipe into a `sed` that strips only the ANSI color markers from the logs, which should result in much clearer logs while keeping the core color functionality in the terminal. 





## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [x] New feature or enhancement (non-breaking change which adds functionality)
- [x] Optimization (non-breaking change that improves code/performance)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Testing checklist

- [x] Unit tests pass (e.g. `dbt-build --unittest`)
- [x] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [x] Full set of integration tests pass (`daqsystemtest_integtest_bundle.sh`)
- [ ] Python tests pass if applicable (e.g. `python -m pytest`)
- [x] Pre-commit hooks run successfully if applicable (e.g. `pre-commit run --all-files`)

### Testing instructions 

- In a clean terminal, obtain latest nightly and check out the dependencies listed above (do _not_ check out this branch just yet)
- Run the `dbt-build` test suite. Make sure you are using the correct path to the `dbt-build` script, eg the one you have checked out (`sourcecode/daq-buildtools/bin/dbt-build`). 
  - Note: using just `dbt-build` will usually not work, this is because `dbt-build` by default goes to the one in cmake! Check `which dbt-build` to verify
- Save and review logs in the usual places
- Now checkout this PR and the latest in the dependency PRs and build as usual
- Run the full integration suite
- Compare the two log files. They should  match aside from the now-stripped ANSI characters. 


## Further checks

- [x] Code is commented where needed, particularly in hard-to-understand areas
- [ ] Code style is correct (`dbt-build --lint`, and/or see https://dune-daq-sw.readthedocs.io/en/latest/packages/styleguide/)
- [ ] If applicable, new tests have been added or an issue has been opened to tackle that in the future.
  (Indicate issue here: # (issue))

