### PR TITLE
Johnfreeman/daq release issue500

### DIFF
--- a/bin/dbt-build
+++ b/bin/dbt-build
@@ -250,8 +250,15 @@ if not os.path.exists("CMakeCache.txt"):
 
     stringio_obj3 = io.StringIO()
     the_which_cmd = sh.Command("which")  # Needed because of a complex alias, at least on mu2edaq
-    the_which_cmd("moo", _out=stringio_obj3)  # Will raise helpful exception if moo not found
-    moo_path=stringio_obj3.getvalue().strip().split()[-1]
+
+    possible_moo_arg = ""
+    try:
+       the_which_cmd("moo", _out=stringio_obj3)  # Will raise helpful exception if moo not found
+    except:
+       pass
+    else:
+       moo_path=stringio_obj3.getvalue().strip().split()[-1]
+       possible_moo_arg = f"-DMOO_CMD={moo_path}"
 
     starttime_cfggen_d=get_time("as_date")
     starttime_cfggen_s=get_time("as_seconds_since_epoch")
@@ -264,7 +271,7 @@ if not os.path.exists("CMakeCache.txt"):
     if args.cmake_msg_lvl:
         cmake_msg_lvl = args.cmake_msg_lvl
 
-    fullcmd="{} -DCMAKE_POLICY_DEFAULT_CMP0116=OLD -DCMAKE_MESSAGE_LOG_LEVEL={} -DMOO_CMD={} -DDBT_ROOT={} -DDBT_DEBUG={} -DDBT_OPTIMIZE_FLAG={} -DCMAKE_INSTALL_PREFIX={} -G Ninja {}".format(cmake, cmake_msg_lvl, moo_path, os.environ["DBT_ROOT"], debug_build, args.optimize_flag, INSTALLDIR, SRCDIR)
+    fullcmd="{} -DCMAKE_POLICY_DEFAULT_CMP0116=OLD -DCMAKE_MESSAGE_LOG_LEVEL={} {} -DDBT_ROOT={} -DDBT_DEBUG={} -DDBT_OPTIMIZE_FLAG={} -DCMAKE_INSTALL_PREFIX={} -G Ninja {}".format(cmake, cmake_msg_lvl, possible_moo_arg, os.environ["DBT_ROOT"], debug_build, args.optimize_flag, INSTALLDIR, SRCDIR)
 
     if args.sanitize:
        fullcmd = f"{fullcmd} -DDBT_SANITIZE={args.sanitize}"

--- a/bin/dbt-info
+++ b/bin/dbt-info
@@ -15,23 +15,16 @@ else:
 
 
 sys.path.append(f'{DBT_ROOT}/scripts')
-from dbt_setup_tools import error, run_command
+from dbt_setup_tools import error, run_command, get_target_package_name
 
 this_script = os.path.basename(__file__)
+release_dir = os.environ["SPACK_RELEASES_DIR"] + "/" + os.environ["SPACK_RELEASE"]
+
+target_package = get_target_package_name(release_dir)
 
 def env_check():
     if not "SPACK_ROOT" in os.environ:
         error("It doesn't appear Spack was set up; exiting...")
-
-def is_far_detector_release():
-   if "FD" in os.environ["SPACK_RELEASE"] or "fd" in os.environ["SPACK_RELEASE"]:
-      is_fd = True
-   elif "ND" in os.environ["SPACK_RELEASE"] or "nd" in os.environ["SPACK_RELEASE"]:
-      is_fd = False
-   else:
-      error("Unable to determine if this release is for the far detector or the near detector; exiting...")
-
-   return is_fd
 
 def get_target_dir(package):
    res = subprocess.Popen(f"realpath $(spack location -p {package})/../..", 
@@ -57,32 +50,25 @@ def release_help():
 
 def release_info():
 
-    try:
-      releasedata = get_release_data("coredaq")
-    except:
-      releasedata = get_release_data("dunedaq")
+   releasedata = get_release_data("coredaq")
 
-    base_release = releasedata["release"]
-    target_dir = "Error"
+   base_release = releasedata["release"]
+   target_dir = "Error"
 
-    if is_far_detector_release():
-        releasedata = get_release_data("fddaq")
-        target_dir = get_target_dir("fddaq")
-    else:
-        releasedata = get_release_data("nddaq")
-        target_dir = get_target_dir("nddaq")
+   releasedata = get_release_data(target_package)
+   target_dir = get_target_dir(target_package)
 
-    full_release = releasedata["release"]
-    full_release_type = releasedata["type"]
+   full_release = releasedata["release"]
+   full_release_type = releasedata["type"]
     
-    pos = target_dir.find(full_release)
-    release_dir = target_dir[:pos + len(full_release)]
+   pos = target_dir.find(full_release)
+   release_dir = target_dir[:pos + len(full_release)]
 
-    print(f"Release type: {full_release_type}")
-    print(f"Release name: {full_release}")
-    print(f"Base release name: {base_release}")
-    print(f"Release dir: {release_dir}")
-    
+   print(f"Release type: {full_release_type}")
+   print(f"Release name: {full_release}")
+   print(f"Base release name: {base_release}")
+   print(f"Release dir: {release_dir}")
+ 
 def release_size_help():
    print(f"\n{this_script} release_size  # No additional arguments")
 
@@ -135,22 +121,11 @@ def package_info(requested_pkg, ok_to_miss = False):
 
    was_found = False
 
-   try:
-     base_data = get_release_data("coredaq")
-   except:
-     base_data = get_release_data("dunedaq")
+   base_data = get_release_data("coredaq")
 
-   is_fd = is_far_detector_release()
+   release_data = get_release_data(target_package)
 
-   if is_fd:
-      fd_or_nd_data = get_release_data("fddaq")
-   else:
-      fd_or_nd_data = get_release_data("nddaq")
-
-   try:
-     base_packages = base_data["coredaq"]
-   except:
-     base_packages = base_data["dunedaq"]
+   base_packages = base_data["coredaq"]
 
    for pkg in base_packages:
       if pkg["name"] == requested_pkg or requested_pkg == "all":
@@ -159,12 +134,7 @@ def package_info(requested_pkg, ok_to_miss = False):
          if requested_pkg != "all":
              return
 
-   if is_fd:
-      datakey = "fddaq"
-   else:
-      datakey = "nddaq"
-
-   for pkg in fd_or_nd_data[ datakey ]:
+   for pkg in release_data[ target_package ]:
       if pkg["name"] == requested_pkg or requested_pkg == "all":
          was_found = True
          package_print(pkg)
@@ -237,12 +207,7 @@ def process_pymodule(package):
       # installation, get version from YAML file from which the python
       # packages are locally installed
 
-      is_fd = is_far_detector_release()
-
-      if is_fd:
-         data = get_release_data("fddaq")
-      else:
-         data = get_release_data("nddaq")
+      data = get_release_data(target_package)
 
       pyvenv_file = "%s/%s/pyvenv_requirements.txt" % (os.environ["SPACK_RELEASES_DIR"], os.environ["SPACK_RELEASE"])
       assert os.path.exists(pyvenv_file)

--- a/scripts/dbt-setup-release.sh
+++ b/scripts/dbt-setup-release.sh
@@ -144,9 +144,7 @@ if [[ "$retval" != "0" ]]; then
     return $retval
 fi
 
-target_package="unknown"
-[[ "$SPACK_RELEASE" =~ (ND|nd) ]] && target_package=nddaq
-[[ "$SPACK_RELEASE" =~ (FD|fd) ]] && target_package=fddaq
+target_package=$( get_target_package "${SPACK_RELEASES_DIR}/${RELEASE_TAG}" )
 
 # For dbt-setup-release, we don't need to drag in build-only dependencies
 variant="~dev"

--- a/scripts/dbt-setup-release.sh
+++ b/scripts/dbt-setup-release.sh
@@ -144,7 +144,7 @@ if [[ "$retval" != "0" ]]; then
     return $retval
 fi
 
-target_package=$( get_target_package "${SPACK_RELEASES_DIR}/${RELEASE_TAG}" )
+target_package=$( get_target_package_name "${SPACK_RELEASES_DIR}/${RELEASE_TAG}" )
 
 # For dbt-setup-release, we don't need to drag in build-only dependencies
 spack_load_target_package ${target_package}~dev

--- a/scripts/dbt-setup-release.sh
+++ b/scripts/dbt-setup-release.sh
@@ -147,9 +147,8 @@ fi
 target_package=$( get_target_package "${SPACK_RELEASES_DIR}/${RELEASE_TAG}" )
 
 # For dbt-setup-release, we don't need to drag in build-only dependencies
-variant="~dev"
+spack_load_target_package ${target_package}~dev
 
-spack_load_target_package $target_package $variant
 retval=$?
 if [[ "$retval" != "0" ]]; then
     error "Failed to load spack target package \"$target_package\". Returning..."

--- a/scripts/dbt-setup-tools.sh
+++ b/scripts/dbt-setup-tools.sh
@@ -224,24 +224,8 @@ function spack_load_target_package() {
     if ! spack find --variants coredaq | grep -q "$daq_pkg_variant"; then
         daq_pkg_variant=""
     fi
-    if [[ $spack_pkgname =~ (nd|fd|core|dune)daq || $spack_pkgname == "externals" ]]; then
-        spack_pkg="$spack_pkgname@${SPACK_RELEASE}${daq_pkg_variant}"
-    else
-	local base_release=$( spack find --format "{version}" coredaq${daq_pkg_variant} )
 
-	# JCF, Apr-11-2024: Check and see if the old name for the core
-	# packages is used in this release
-
-	if [[ "$base_release" =~ "No package matches the query" ]]; then
-	    base_release=$( spack find --format "{version}" dunedaq )
-	fi
-
-	if [[ "$base_release" =~ "No package matches the query" ]]; then
-	    spack_pkg=$spack_pkgname
-        else
-	    spack_pkg=$spack_pkgname@${base_release}
-	fi
-    fi
+    spack_pkg="$spack_pkgname@${SPACK_RELEASE}${daq_pkg_variant}"
 
     pkg_loaded_status=$(spack find --loaded -l $spack_pkg | sed -r -n '/^\w{7} '$spack_pkgname'/p' )
     

--- a/scripts/dbt-setup-tools.sh
+++ b/scripts/dbt-setup-tools.sh
@@ -359,7 +359,7 @@ function prioritize_directories() {
 }
 
 # This function is needed as part of daq-release Issue #500
-function get_target_package() {
+function get_target_package_name() {
     local release_dir=$1
 
     spec_file=$( ls $release_dir/spec_*_log.txt )
@@ -368,10 +368,10 @@ function get_target_package() {
 	if [[ -n $target_package ]]; then
 	    echo $target_package
 	else
-	    echo "get_target_package_error2"
+	    echo "get_target_package_name_error2"
 	fi
     else
-	echo "get_target_package_error1"
+	echo "get_target_package_name_error1"
     fi
 }
 

--- a/scripts/dbt-setup-tools.sh
+++ b/scripts/dbt-setup-tools.sh
@@ -372,5 +372,21 @@ function prioritize_directories() {
 
 }
 
+# This function is needed as part of daq-release Issue #500
+function get_target_package() {
+    local release_dir=$1
+
+    spec_file=$( ls $release_dir/spec_*_log.txt )
+    if [[ -n $spec_file ]]; then
+	target_package=$( echo $spec_file | sed -r 's!.*/spec_([^_]+)_log.txt!\1!' )
+	if [[ -n $target_package ]]; then
+	    echo $target_package
+	else
+	    echo "get_target_package_error2"
+	fi
+    else
+	echo "get_target_package_error1"
+    fi
+}
 
 #------------------------------------------------------------------------------

--- a/scripts/dbt-setup-tools.sh
+++ b/scripts/dbt-setup-tools.sh
@@ -224,8 +224,24 @@ function spack_load_target_package() {
     if ! spack find --variants coredaq | grep -q "$daq_pkg_variant"; then
         daq_pkg_variant=""
     fi
+    if [[ $spack_pkgname =~ (nd|fd|core|dune)daq || $spack_pkgname == "externals" ]]; then
+        spack_pkg="$spack_pkgname@${SPACK_RELEASE}${daq_pkg_variant}"
+    else
+	local base_release=$( spack find --format "{version}" coredaq${daq_pkg_variant} )
 
-    spack_pkg="$spack_pkgname@${SPACK_RELEASE}${daq_pkg_variant}"
+	# JCF, Apr-11-2024: Check and see if the old name for the core
+	# packages is used in this release
+
+	if [[ "$base_release" =~ "No package matches the query" ]]; then
+	    base_release=$( spack find --format "{version}" dunedaq )
+	fi
+
+	if [[ "$base_release" =~ "No package matches the query" ]]; then
+	    spack_pkg=$spack_pkgname
+        else
+	    spack_pkg=$spack_pkgname@${base_release}
+	fi
+    fi
 
     pkg_loaded_status=$(spack find --loaded -l $spack_pkg | sed -r -n '/^\w{7} '$spack_pkgname'/p' )
     

--- a/scripts/dbt-setup-tools.sh
+++ b/scripts/dbt-setup-tools.sh
@@ -217,18 +217,6 @@ function spack_load_target_package() {
 
     local spack_pkg=$1
 
-    # if [[ $daq_pkg_variant != "" ]]; then
-    #     spack_pkg="$spack_pkgname@${SPACK_RELEASE}${daq_pkg_variant}"
-    # else
-    # 	local base_release=$( spack find --format "{version}" coredaq+dev ) # +dev arbitrary, both +dev/~dev have same base release
-
-    # 	if [[ "$base_release" =~ "No package matches the query" ]]; then
-    # 	    spack_pkg=$spack_pkgname
-    #     else
-    # 	    spack_pkg=$spack_pkgname@${base_release}
-    # 	fi
-    # fi
-
     pkg_loaded_status=$(spack find --loaded -l $spack_pkg | sed -r -n '/^\w{7} '$spack_pkgname'/p' )
     
     if [[ -z $pkg_loaded_status || $pkg_loaded_status =~ "0 loaded packages" || $pkg_loaded_status =~ "No package matches the query: $spack_pkgname" ]]; then

--- a/scripts/dbt-setup-tools.sh
+++ b/scripts/dbt-setup-tools.sh
@@ -215,33 +215,19 @@ function spack_setup_env() {
 #------------------------------------------------------------------------------
 function spack_load_target_package() {
 
-    local spack_pkgname=$1
-    local spack_pkg
+    local spack_pkg=$1
 
-    local daq_pkg_variant=${2:-+dev}
+    # if [[ $daq_pkg_variant != "" ]]; then
+    #     spack_pkg="$spack_pkgname@${SPACK_RELEASE}${daq_pkg_variant}"
+    # else
+    # 	local base_release=$( spack find --format "{version}" coredaq+dev ) # +dev arbitrary, both +dev/~dev have same base release
 
-    # For backwards compatibility, only use a variant if it exists
-    if ! spack find --variants coredaq | grep -q "$daq_pkg_variant"; then
-        daq_pkg_variant=""
-    fi
-    if [[ $spack_pkgname =~ (nd|fd|core|dune)daq || $spack_pkgname == "externals" ]]; then
-        spack_pkg="$spack_pkgname@${SPACK_RELEASE}${daq_pkg_variant}"
-    else
-	local base_release=$( spack find --format "{version}" coredaq${daq_pkg_variant} )
-
-	# JCF, Apr-11-2024: Check and see if the old name for the core
-	# packages is used in this release
-
-	if [[ "$base_release" =~ "No package matches the query" ]]; then
-	    base_release=$( spack find --format "{version}" dunedaq )
-	fi
-
-	if [[ "$base_release" =~ "No package matches the query" ]]; then
-	    spack_pkg=$spack_pkgname
-        else
-	    spack_pkg=$spack_pkgname@${base_release}
-	fi
-    fi
+    # 	if [[ "$base_release" =~ "No package matches the query" ]]; then
+    # 	    spack_pkg=$spack_pkgname
+    #     else
+    # 	    spack_pkg=$spack_pkgname@${base_release}
+    # 	fi
+    # fi
 
     pkg_loaded_status=$(spack find --loaded -l $spack_pkg | sed -r -n '/^\w{7} '$spack_pkgname'/p' )
     

--- a/scripts/dbt-workarea-env.sh
+++ b/scripts/dbt-workarea-env.sh
@@ -110,7 +110,7 @@ if [[ -z "${DBT_PACKAGE_SETUP_DONE}" ]]; then
     echo -e "${COL_GREEN}This script hasn't yet been sourced (successfully) in this shell; setting up the build environment${COL_RESET}\n"
     
     if [[ "$DBT_PKG_SET" =~ "daqpackages" ]]; then
-        target_package=$( get_target_package $SPACK_RELEASES_DIR/$SPACK_RELEASE )
+        target_package=$( get_target_package_name $SPACK_RELEASES_DIR/$SPACK_RELEASE )
     else
 	target_package=$DBT_PKG_SET
     fi

--- a/scripts/dbt-workarea-env.sh
+++ b/scripts/dbt-workarea-env.sh
@@ -110,9 +110,7 @@ if [[ -z "${DBT_PACKAGE_SETUP_DONE}" ]]; then
     echo -e "${COL_GREEN}This script hasn't yet been sourced (successfully) in this shell; setting up the build environment${COL_RESET}\n"
     
     if [[ "$DBT_PKG_SET" =~ "daqpackages" ]]; then
-        target_package=unknown
-	[[ "$SPACK_RELEASE" =~ (ND|nd) ]] && target_package=nddaq
-	[[ "$SPACK_RELEASE" =~ (FD|fd) ]] && target_package=fddaq
+        target_package=$( get_target_package $SPACK_RELEASES_DIR/$SPACK_RELEASE )
     else
 	target_package=$DBT_PKG_SET
     fi

--- a/scripts/dbt-workarea-env.sh
+++ b/scripts/dbt-workarea-env.sh
@@ -115,7 +115,7 @@ if [[ -z "${DBT_PACKAGE_SETUP_DONE}" ]]; then
 	target_package=$DBT_PKG_SET
     fi
 
-    spack_load_target_package $target_package
+    spack_load_target_package ${target_package}+dev
 
     retval=$?
     if [[ "$retval" != "0" ]]; then

--- a/scripts/dbt_setup_tools.py
+++ b/scripts/dbt_setup_tools.py
@@ -81,3 +81,18 @@ def run_command(cmd):
 
     if res.returncode != 0:
         error(f"There was a problem running \"{cmd}\" (return value {res.returncode}); exiting...")
+
+# This function is needed as part of daq-release Issue #500
+# Its namesake bash counterpart can be found in dbt-setup-tools.sh
+
+def get_target_package_name(release_dir):
+    spec_files = glob.glob(f"{release_dir}/spec_*_log.txt")
+    assert len(spec_files) == 1, f"Glob of {release_dir}/spec_*_log.txt didn't yield one and only one file"
+
+    spec_file = spec_files[0]
+
+    assert os.path.exists(spec_file)
+    res = re.search(r".*/spec_([^_]+)_log.txt", spec_file)
+
+    assert res
+    return res.group(1)


### PR DESCRIPTION
# Description

This is a backwards-compatible refactor of daq-buildtools which removed hardwired references to fddaq and nddaq which will allow it to flexibly work with other development/production environments in the future; see #327 and DUNE-DAQ/daq-release#500 for more details on this. 

_If full decription and testing details are included on a parent issue, please link to that here._
Testing details in #327 

_Please also include instructions for how a reviewer can test your changes._

We have the `test_daq-buildtools.sh` script in `daq-release` which is a set of regression tests. Also, should check that `dbt-info` still appears to work. This should be done for:
- A random nightly
- A random candidate or frozen release
- `UFDDU_DEV_251205_A9`, which is a non-`fddaq`, non-`nddaq` environment I created as part of the DUNE-DAQ/daq-release#500 development process but which is also a great example of a "new" environment that daq-buildtools will currently choke on but which would work given this PR. 


## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [X] Optimization (non-breaking change that improves code/performance)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

The remaining checklists, below, aren't applicable to `daq-buildtools`. 

## Testing checklist

- [ ] Unit tests pass (e.g. `dbt-build --unittest`)
- [ ] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [ ] Full set of integration tests pass (`daqsystemtest_integtest_bundle.sh`)
- [ ] Python tests pass if applicable (e.g. `python -m pytest`)
- [ ] Pre-commit hooks run successfully if applicable (e.g. `pre-commit run --all-files`)

_Comments here on the testing_

## Further checks

- [ ] Code is commented where needed, particularly in hard-to-understand areas
- [ ] Code style is correct (`dbt-build --lint`, and/or see https://dune-daq-sw.readthedocs.io/en/latest/packages/styleguide/)
- [ ] If applicable, new tests have been added or an issue has been opened to tackle that in the future.
  (Indicate issue here: # (issue))

