### PR TITLE
Johnfreeman/issue329 extv2.3 support

### DIFF
--- a/bin/clonevirtualenv.py
+++ b/bin/clonevirtualenv.py
@@ -82,7 +82,10 @@ def clone_virtualenv(src_dir, dst_dir, tarball):
             found_tarball = True
     if found_tarball:
         with tarfile.open(tarball,"r:gz") as tarfile_obj:
-            tarfile_obj.extractall(os.path.dirname(dst_dir), filter="tar")
+            if sys.version_info >= (3, 11):
+                tarfile_obj.extractall(os.path.dirname(dst_dir), filter="tar")
+            else:
+                tarfile_obj.extractall(os.path.dirname(dst_dir))
     else:
         shutil.copytree(src_dir, dst_dir, symlinks=True)
     for rootDir, subdirs, filenames in os.walk(dst_dir):

--- a/bin/clonevirtualenv.py
+++ b/bin/clonevirtualenv.py
@@ -82,7 +82,7 @@ def clone_virtualenv(src_dir, dst_dir, tarball):
             found_tarball = True
     if found_tarball:
         with tarfile.open(tarball,"r:gz") as tarfile_obj:
-            tarfile_obj.extractall(os.path.dirname(dst_dir))
+            tarfile_obj.extractall(os.path.dirname(dst_dir), filter="tar")
     else:
         shutil.copytree(src_dir, dst_dir, symlinks=True)
     for rootDir, subdirs, filenames in os.walk(dst_dir):

--- a/bin/dbt-build
+++ b/bin/dbt-build
@@ -271,7 +271,7 @@ if not os.path.exists("CMakeCache.txt"):
     if args.cmake_msg_lvl:
         cmake_msg_lvl = args.cmake_msg_lvl
 
-    fullcmd="{} -DCMAKE_POLICY_DEFAULT_CMP0116=OLD -DCMAKE_MESSAGE_LOG_LEVEL={} {} -DDBT_ROOT={} -DDBT_DEBUG={} -DDBT_OPTIMIZE_FLAG={} -DCMAKE_INSTALL_PREFIX={} -G Ninja {}".format(cmake, cmake_msg_lvl, possible_moo_arg, os.environ["DBT_ROOT"], debug_build, args.optimize_flag, INSTALLDIR, SRCDIR)
+    fullcmd="{} -DCMAKE_POLICY_DEFAULT_CMP0116=OLD -DCMAKE_POLICY_DEFAULT_CMP0144=OLD -DCMAKE_POLICY_DEFAULT_CMP0167=OLD -DPYBIND11_FINDPYTHON=1 -DCMAKE_MESSAGE_LOG_LEVEL={} {} -DDBT_ROOT={} -DDBT_DEBUG={} -DDBT_OPTIMIZE_FLAG={} -DCMAKE_INSTALL_PREFIX={} -G Ninja {}".format(cmake, cmake_msg_lvl, possible_moo_arg, os.environ["DBT_ROOT"], debug_build, args.optimize_flag, INSTALLDIR, SRCDIR)
 
     if args.sanitize:
        fullcmd = f"{fullcmd} -DDBT_SANITIZE={args.sanitize}"

--- a/bin/dbt-build
+++ b/bin/dbt-build
@@ -271,7 +271,13 @@ if not os.path.exists("CMakeCache.txt"):
     if args.cmake_msg_lvl:
         cmake_msg_lvl = args.cmake_msg_lvl
 
-    fullcmd="{} -DCMAKE_POLICY_DEFAULT_CMP0116=OLD -DCMAKE_POLICY_DEFAULT_CMP0144=OLD -DCMAKE_POLICY_DEFAULT_CMP0167=OLD -DPYBIND11_FINDPYTHON=1 -DCMAKE_MESSAGE_LOG_LEVEL={} {} -DDBT_ROOT={} -DDBT_DEBUG={} -DDBT_OPTIMIZE_FLAG={} -DCMAKE_INSTALL_PREFIX={} -G Ninja {}".format(cmake, cmake_msg_lvl, possible_moo_arg, os.environ["DBT_ROOT"], debug_build, args.optimize_flag, INSTALLDIR, SRCDIR)
+    cmake_version_output = subprocess.check_output(["cmake", "--version"], text=True)
+    cmake_version = cmake_version_output.splitlines()[0].split()[-1]
+
+    if cmake_version != "3.26.3":  # i.e., if it's not the older CMake from externals v2.2
+       fullcmd="{} -DCMAKE_POLICY_DEFAULT_CMP0116=OLD -DCMAKE_POLICY_DEFAULT_CMP0144=OLD -DCMAKE_POLICY_DEFAULT_CMP0167=OLD -DPYBIND11_FINDPYTHON=1 -DCMAKE_MESSAGE_LOG_LEVEL={} {} -DDBT_ROOT={} -DDBT_DEBUG={} -DDBT_OPTIMIZE_FLAG={} -DCMAKE_INSTALL_PREFIX={} -G Ninja {}".format(cmake, cmake_msg_lvl, possible_moo_arg, os.environ["DBT_ROOT"], debug_build, args.optimize_flag, INSTALLDIR, SRCDIR)
+    else:
+       fullcmd="{} -DCMAKE_POLICY_DEFAULT_CMP0116=OLD -DCMAKE_MESSAGE_LOG_LEVEL={} {} -DDBT_ROOT={} -DDBT_DEBUG={} -DDBT_OPTIMIZE_FLAG={} -DCMAKE_INSTALL_PREFIX={} -G Ninja {}".format(cmake, cmake_msg_lvl, possible_moo_arg, os.environ["DBT_ROOT"], debug_build, args.optimize_flag, INSTALLDIR, SRCDIR)
 
     if args.sanitize:
        fullcmd = f"{fullcmd} -DDBT_SANITIZE={args.sanitize}"

--- a/bin/dbt-info
+++ b/bin/dbt-info
@@ -255,7 +255,7 @@ def sourcecode_info():
       for repo in repos:
          os.chdir(repo)
          print(f"%s: " % (repo.split("/")[-1]), end="")
-         run_command('echo -n \"$( git rev-parse --abbrev-ref HEAD )$( git diff --no-ext-diff --quiet --exit-code || echo \* ) [$( git rev-parse --short HEAD )]\" ')
+         run_command('echo -n \"$( git rev-parse --abbrev-ref HEAD )$( git diff --no-ext-diff --quiet --exit-code || echo \\* ) [$( git rev-parse --short HEAD )]\" ')
    else: 
       print('There are no locally checked out packages in $DBT_AREA_ROOT/sourcecode')
    print()

--- a/scripts/dbt-workarea-env.sh
+++ b/scripts/dbt-workarea-env.sh
@@ -127,6 +127,10 @@ if [[ -z "${DBT_PACKAGE_SETUP_DONE}" ]]; then
     echo "Now loading devtools for latest CMake, gcc, etc."
     spack load devtools || echo -e "\nWARNING: this script was unable to load \"devtools\"; you may be using an older CMake as a result (run \"which cmake\" to check)\n"
 
+    gcc_version=$( gcc --version | head -1 | sed -r 's/.*\s+([0-9]+.[0-9]+.[0-9]+).*/\1/' )
+    echo "gcc $gcc_version is used, so loading corresponding gcc-runtime $gcc_version"
+    spack load gcc-runtime@${gcc_version} || echo -e "\nWARNING: unable to load the correct gcc-runtime\n"
+
     # Assumption is you've already spack loaded python, etc...
     local_venv_dir=${DBT_AREA_ROOT}/${DBT_VENV}
     release_venv_dir=`realpath ${SPACK_RELEASES_DIR}/$SPACK_RELEASE/${DBT_VENV}`


### PR DESCRIPTION
# Description

Parent Issue is DUNE-DAQ/daq-release#510.

This PR updates daq-buildtools so that it will work smoothly (i.e., without warnings, etc.) both with externals v2.2 and v2.3. This PR is a consequence of the switchover to externals v2.3, described in the parent Issue linked above. 

This PR will close issue #329.

As there will be a gradual transition over to externals v2.3, during which time developers will be working with both externals v2.2 and externals v2.3-based areas, the changes in this issue are intended to allow daq-buildtools to work as smoothly as possible under both sets of externals. Testing it will involve insuring that daq-buildtools works normally under both circumstances; note that `EXTFD_DEV_260115` is essentially the canonical externals v2.3 test build which we have. 

Testing can include the obvious things, including running `test_daq-buildtools.sh` after edits are made to it so as to use this PR branch of daq-buildtools and the desired work area. 

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [X] Optimization (non-breaking change that improves code/performance)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

The boxes below are inapplicable for daq-buildtools changes; testing should proceed as described above. 

## Testing checklist

- [ ] Unit tests pass (e.g. `dbt-build --unittest`)
- [ ] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [ ] Full set of integration tests pass (`daqsystemtest_integtest_bundle.sh`)
- [ ] Python tests pass if applicable (e.g. `python -m pytest`)
- [ ] Pre-commit hooks run successfully if applicable (e.g. `pre-commit run --all-files`)

_Comments here on the testing_

## Further checks

- [ ] Code is commented where needed, particularly in hard-to-understand areas
- [ ] Code style is correct (`dbt-build --lint`, and/or see https://dune-daq-sw.readthedocs.io/en/latest/packages/styleguide/)
- [ ] If applicable, new tests have been added or an issue has been opened to tackle that in the future.
  (Indicate issue here: # (issue))

