### PR TITLE
JCF: Issue #332: add a pythoncode/ directory parallel to the sourceco…

### DIFF
--- a/bin/dbt-info
+++ b/bin/dbt-info
@@ -243,11 +243,17 @@ def sourcecode_help():
    print(f"\n{this_script} sourcecode  # No additional arguments")
 
 def sourcecode_info():
-   codepath = "%s/%s" % (os.environ["DBT_AREA_ROOT"], "sourcecode")
-   if not os.path.exists( codepath ):
-      error(f"Are you sure you have a work area set up? Unable to find expected path {codepath}; exiting...")
-   
-   repos = [os.path.join(codepath, d) for d in os.listdir(codepath) if os.path.isdir(os.path.join(codepath, d))]
+   codepaths = []
+   for subdir in ["sourcecode", "pythoncode"]:
+      codepaths.append( "%s/%s" % (os.environ["DBT_AREA_ROOT"], subdir) )
+
+   repos = []
+   for codepath in codepaths:
+      if not os.path.exists( codepath ):
+         error(f"Are you sure you have a work area set up? Unable to find expected path {codepath}; exiting...")
+
+      for repo in [os.path.join(codepath, d) for d in os.listdir(codepath) if os.path.isdir(os.path.join(codepath, d))]:
+         repos.append(repo)
 
    print()
    if repos:
@@ -260,7 +266,7 @@ def sourcecode_info():
       print('There are no locally checked out packages in $DBT_AREA_ROOT/sourcecode')
    print()
 
-   print(f"Source code for packages not checked out locally is in {os.environ.get('DUNE_DAQ_RELEASE_SOURCE')}")
+   print(f"Source code for packages not checked out locally is in\n{os.environ.get('DUNE_DAQ_RELEASE_SOURCE')}")
 
 def full_help():
     release_help()

--- a/bin/dbtx-create-workarea-from-recipe.py
+++ b/bin/dbtx-create-workarea-from-recipe.py
@@ -6,6 +6,8 @@ exec(open(f'{DBT_ROOT}/scripts/dbt_setup_constants.py').read())
 
 import argparse
 from datetime import datetime
+from pathlib import Path
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -91,9 +93,7 @@ def create_workarea_from_recipe(recipe_source, use_ref, build, use_ssh_repos, wo
     '''], check=True, executable='/bin/bash')
 
     workarea_path = os.path.abspath(workarea_name)
-    
-    sourcecode_path = os.path.join(workarea_path, "sourcecode")
-    os.chdir(sourcecode_path)
+    os.chdir(workarea_path)
 
     #now loop over the repos in the recipe, clone and checkout what's needed
     for repo in repos:
@@ -105,7 +105,7 @@ def create_workarea_from_recipe(recipe_source, use_ref, build, use_ssh_repos, wo
         print(f"\nCloning {name} from {url}...")
         subprocess.run(['git', 'clone', url, name], check=True)
 
-        repo_path = os.path.join(sourcecode_path, name)
+        repo_path = f"{workarea_path}/{name}"
         os.chdir(repo_path)
 
         #fetch everything
@@ -142,7 +142,14 @@ def create_workarea_from_recipe(recipe_source, use_ref, build, use_ssh_repos, wo
             print(f"  Checking out commit: {commit}")
             subprocess.run(['git', 'checkout', commit], check=True)
 
-        os.chdir(sourcecode_path)
+        os.chdir(workarea_path)
+
+        if os.path.exists(f"{name}/CMakeLists.txt"):
+            shutil.move(f"{Path.cwd()}/{name}", f"{workarea_path}/sourcecode/{name}")
+        elif os.path.exists(f"{name}/pyproject.toml"):
+            shutil.move(f"{Path.cwd()}/{name}", f"{workarea_path}/pythoncode/{name}")
+        else:
+            assert False, f"Unable to determine what type of repo {Path.cwd()}/{name} is"
 
     os.chdir(workarea_path)  # Back to workarea root
 

--- a/bin/dbtx-save-workarea-recipe.py
+++ b/bin/dbtx-save-workarea-recipe.py
@@ -113,18 +113,21 @@ def save_workarea_recipe(recipe_name,require_valid_refs):
         raise CustomError("DUNE_DAQ_BASE_RELEASE not set in environment! "
                           "Setup dunedaq before running this script.")
 
-    sourcecode_dir = os.path.join(os.environ.get("DBT_AREA_ROOT"), "sourcecode")
+    sourcecode_dirs = []
+    for subdir in ["sourcecode", "pythoncode"]:
+        sourcecode_dirs.append( os.path.join(os.environ.get("DBT_AREA_ROOT"), subdir) )
 
     repos = []
     all_commits_valid = True
     all_refs_valid = True
 
-    for entry in os.listdir(sourcecode_dir):
-        repo_path = os.path.join(sourcecode_dir, entry)
-        if os.path.isdir(repo_path) and os.path.isdir(os.path.join(repo_path, '.git')):
-            repos.append(get_repo_info(repo_path))
-            if not repos[-1]['commit_valid']: all_commits_valid = False
-            if not repos[-1]['ref_valid']: all_refs_valid = False
+    for sourcecode_dir in sourcecode_dirs:
+        for entry in os.listdir(sourcecode_dir):
+            repo_path = os.path.join(sourcecode_dir, entry)
+            if os.path.isdir(repo_path) and os.path.isdir(os.path.join(repo_path, '.git')):
+                repos.append(get_repo_info(repo_path))
+                if not repos[-1]['commit_valid']: all_commits_valid = False
+                if not repos[-1]['ref_valid']: all_refs_valid = False
 
     #check that all commits are ok, and optionally that all refs are ok
     if not all_commits_valid:

--- a/docs/README.md
+++ b/docs/README.md
@@ -80,11 +80,12 @@ MyTopDir
 ├── dbt-workarea-constants.sh
 ├── env.sh
 ├── log
+├── pythoncode
 └── sourcecode
     ├── CMakeLists.txt
     └── dbt-build-order.cmake
 ```
-The next section of this document concerns how to build code in your new work area. However, if you'd like to learn about how to retrieve information about your work area such as the release of the DUNE DAQ suite it builds against, you can skip ahead to [Finding Info on Your Work Area](#Finding_Info).
+Here, the `pythoncode` directory is intended for pure Python repos, while the `sourcecode` directory is intended for C++ or hybrid C++/Python repos (i.e., packages with `CMakeLists.txt` at their base). The next section of this document concerns how to build code in your new work area. However, if you'd like to learn about how to retrieve information about your work area such as the release of the DUNE DAQ suite it builds against, you can skip ahead to [Finding Info on Your Work Area](#Finding_Info).
 
 ### Advanced `dbt-create` options
 

--- a/scripts/dbt_create.py
+++ b/scripts/dbt_create.py
@@ -152,8 +152,9 @@ TARGETDIR=os.getcwd() # Get full path
 BUILDDIR=f"{TARGETDIR}/build"
 LOGDIR=f"{TARGETDIR}/log"
 SRCDIR=f"{TARGETDIR}/sourcecode"
+PYTHONDIR=f"{TARGETDIR}/pythoncode"
 
-for workareadir in [BUILDDIR, LOGDIR, SRCDIR]:
+for workareadir in [BUILDDIR, LOGDIR, SRCDIR, PYTHONDIR]:
     os.mkdir(workareadir)
 
 os.chdir(SRCDIR)


### PR DESCRIPTION
Add a `pythoncode/` directory parallel to the `sourcecode/` directory for developing pure Python packages in DUNE-DAQ

# Description
See issue #332 for details. But basically, this does what it says on the label: there's now an official subdirectory where developers can put their Python repos. Note that this PR is fairly bare bones, in that it does _not_ add any special tooling (e.g., `dbt-build` could theoretically call `pip install -U .` on every repo in `pythoncode`, but it doesn't). 

Addresses issue #332.

_Please also include instructions for how a reviewer can test your changes._
Does `pythoncode/` exist? Can `dbt-info` handle it? What about it the cloning scripts?

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ X] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking change that improves code/performance)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

Checklist below is N/A for daq-buildtools changes. 

## Testing checklist

- [ ] Unit tests pass (e.g. `dbt-build --unittest`)
- [ ] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [ ] Full set of integration tests pass (`daqsystemtest_integtest_bundle.sh`)
- [ ] Python tests pass if applicable (e.g. `python -m pytest`)
- [ ] Pre-commit hooks run successfully if applicable (e.g. `pre-commit run --all-files`)

_Comments here on the testing_

## Further checks

- [ ] Code is commented where needed, particularly in hard-to-understand areas
- [ ] Code style is correct (`dbt-build --lint`, and/or see https://dune-daq-sw.readthedocs.io/en/latest/packages/styleguide/)
- [ ] If applicable, new tests have been added or an issue has been opened to tackle that in the future.
  (Indicate issue here: # (issue))

