### PR TITLE
JCF: Issue #331: have dbt-workarea-env check to see if any repos have…

### DIFF
--- a/scripts/dbt-workarea-env.sh
+++ b/scripts/dbt-workarea-env.sh
@@ -203,6 +203,27 @@ for p in ${DBT_PACKAGES}; do
     add_many_paths DUNEDAQ_DB_PATH "${SOURCE_DIR}/$p"
 done
 
+# If a repo is removed from a work area, we need to ensure
+# <PACKAGENAME>_SHARE is updated accordingly
+
+# To check for candidates, we loop over packages which appear anywhere
+# in the DUNEDAQ_SHARE_PATH colon-separated list with a local
+# installation directory; if so that tips us off that _at least at
+# some point_ it was worked on in this work area
+
+for p in $( echo $DUNEDAQ_SHARE_PATH | tr ":" "\n" | grep $DBT_INSTALL_DIR | sed -r 's!'$DBT_INSTALL_DIR'/(.*)/share!\1!' ); do
+    if [[ ! -d ${SOURCE_DIR}/$p ]]; then  # package is no longer a repo in the work area
+	spack_directory=$( spack find -p $p | sed -r -n 's!.*(/cvmfs/.*)!\1!p' )
+	if [[ -n $spack_directory ]]; then
+	    PNAME=${p^^}
+	    pkg_share="${PNAME//-/_}_SHARE"
+	    declare -xg "${pkg_share}"="$spack_directory/share"
+	else
+	    echo "WARNING: it appears $p was removed from the work area, but unable to reset the $p_SHARE variable" >&2
+	fi
+    fi
+done
+
 prioritize_directories DUNEDAQ_DB_PATH
 
 export PATH PYTHONPATH LD_LIBRARY_PATH CET_PLUGIN_PATH DUNEDAQ_SHARE_PATH DUNEDAQ_DB_PATH


### PR DESCRIPTION
… been removed from the work area, and update the PACKAGENAME_SHARE variables accordingly

# Description

This PR originates from Kurt's observation that if he removes a repo from a work area, even if running `dbt-clean` and `dbt-workarea-env`, the `<PACKAGENAME>_SHARE` variable will still point to the local `install/<PACKAGENAME>` directory. 

Addresses issue #331  

To test, the most obvious thing is to add a repo to a work area, run `dbt-workarea-env`, check that `<PACKAGENAME>_SHARE` (`<PACKAGENAME>` being the name of the repo) now points to the local installation directory, remove the repo from the work area, rerun `dbt-workarea-env`, and check that `<PACKAGENAME>_SHARE` has now been re-pointed to the share directory of the Spack installation on `/cvmfs`. 

Note that  beyond "Type of change" the checklist is not applicable to daq-buildtools (unit tests, etc.)
## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking change that improves code/performance)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Testing checklist

- [ ] Unit tests pass (e.g. `dbt-build --unittest`)
- [ ] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [ ] Full set of integration tests pass (`daqsystemtest_integtest_bundle.sh`)
- [ ] Python tests pass if applicable (e.g. `python -m pytest`)
- [ ] Pre-commit hooks run successfully if applicable (e.g. `pre-commit run --all-files`)

_Comments here on the testing_

## Further checks

- [ ] Code is commented where needed, particularly in hard-to-understand areas
- [ ] Code style is correct (`dbt-build --lint`, and/or see https://dune-daq-sw.readthedocs.io/en/latest/packages/styleguide/)
- [ ] If applicable, new tests have been added or an issue has been opened to tackle that in the future.
  (Indicate issue here: # (issue))

