### PR TITLE
Run linting and code coverage in test workflow

### DIFF
--- a/.github/workflows/test_daq_buildtools.yml
+++ b/.github/workflows/test_daq_buildtools.yml
@@ -44,6 +44,8 @@ jobs:
         #./test_daq-buildtools.sh --dbt-branch ${{ github.head_ref }}
         docker run --rm -it \
           --mount type=bind,src=/cvmfs,dst=/cvmfs,bind-propagation=shared \
+          --mount type=bind,src="$PWD",dst=/workspace,bind-propagation=shared \
+          -w /workspace \
           ghcr.io/dune-daq/nightly-release-alma9:development_v5 \
           ./test_daq-buildtools.sh --dbt-branch ${{ github.head_ref }}
 

--- a/.github/workflows/test_daq_buildtools.yml
+++ b/.github/workflows/test_daq_buildtools.yml
@@ -30,6 +30,27 @@ jobs:
     - name: Check CVMFS
       run: |
         ls -lrt /cvmfs || exit 1
+
+    - name: change dir permission
+      run: |
+        sudo mkdir -p /var/lib/cvmfs
+        sudo chmod -R 777 /var/lib/cvmfs
+  
+    - name: Cache cvmfs cache
+      id: cvmfs_cache
+      uses: actions/cache@main
+      with:
+        path: /var/lib/cvmfs/shared
+        key: cachecvmfs
+
+    - name: restore dir permission
+      run: |
+        sudo chown -R cvmfs:cvmfs /var/lib/cvmfs
+        sudo chmod -R 700 /var/lib/cvmfs
+
+    - name: Pull latest nightly build image
+      run: docker pull ghcr.io/dune-daq/nightly-release-alma9:development_v5
+
     - id: checkout_daq_buildtools
       uses: actions/checkout@v6
       with:
@@ -43,8 +64,8 @@ jobs:
         cd scripts
         #./test_daq-buildtools.sh --dbt-branch ${{ github.head_ref }}
         docker run --rm \
-          --mount type=bind,src=/cvmfs,dst=/cvmfs,bind-propagation=shared \
-          --mount type=bind,src="$PWD",dst=/workspace,bind-propagation=shared \
+          -v /cvmfs:/cvmfs:shared \
+          -v "$PWD":/workspace \
           -w /workspace \
           ghcr.io/dune-daq/nightly-release-alma9:development_v5 \
           ./test_daq-buildtools.sh --dbt-branch ${{ github.head_ref }}

--- a/.github/workflows/test_daq_buildtools.yml
+++ b/.github/workflows/test_daq_buildtools.yml
@@ -59,6 +59,7 @@ jobs:
 
     - name: Run test_daq-buildtools script
       run: |
+        BRANCH="${{ inputs.dbt-branch || github.head_ref || github.ref_name }}"
         cd daq-buildtools-test
         source env.sh
         cd scripts
@@ -68,7 +69,7 @@ jobs:
           -v "$PWD":/workspace \
           -w /workspace \
           ghcr.io/dune-daq/nightly-release-alma9:development_v5 \
-          ./test_daq-buildtools.sh --dbt-branch ${{ github.head_ref }}
+          ./test_daq-buildtools.sh --dbt-branch $BRANCH
 
         
 

--- a/.github/workflows/test_daq_buildtools.yml
+++ b/.github/workflows/test_daq_buildtools.yml
@@ -30,6 +30,7 @@ jobs:
 
   test_daq_buildtools:
     name: Test daq-buildtools
+    needs: load_cvmfs
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/dune-daq/nightly-release-alma9:development_v5

--- a/.github/workflows/test_daq_buildtools.yml
+++ b/.github/workflows/test_daq_buildtools.yml
@@ -42,7 +42,7 @@ jobs:
         source env.sh
         cd scripts
         #./test_daq-buildtools.sh --dbt-branch ${{ github.head_ref }}
-        docker run --rm -it \
+        docker run --rm \
           --mount type=bind,src=/cvmfs,dst=/cvmfs,bind-propagation=shared \
           --mount type=bind,src="$PWD",dst=/workspace,bind-propagation=shared \
           -w /workspace \

--- a/.github/workflows/test_daq_buildtools.yml
+++ b/.github/workflows/test_daq_buildtools.yml
@@ -16,16 +16,33 @@ on:
         description: "Branch from which to run test_daq-buildtools.sh"
 
 jobs:
+  load_cvmfs:
+    name: Load CVMFS
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+
+    steps: 
+    - uses: cvmfs-contrib/github-action-cvmfs@v5
+      with:
+        cvmfs_repositories: 'dunedaq-development.opensciencegrid.org'
+
   test_daq_buildtools:
     name: Test daq-buildtools
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/dune-daq/nightly-release-alma9:development_v5
+      volumes: 
+        - /cvmfs:/cvmfs
     defaults:
       run:
         shell: bash
 
     steps:
+    - name: Check CVMFS
+      run: |
+        ls -lrt /cvmfs || exit 1
     - id: checkout_daq_buildtools
       uses: actions/checkout@v6
       with:

--- a/.github/workflows/test_daq_buildtools.yml
+++ b/.github/workflows/test_daq_buildtools.yml
@@ -36,12 +36,12 @@ jobs:
         sudo mkdir -p /var/lib/cvmfs
         sudo chmod -R 777 /var/lib/cvmfs
   
-    - name: Cache cvmfs cache
-      id: cvmfs_cache
-      uses: actions/cache@main
-      with:
-        path: /var/lib/cvmfs/shared
-        key: cachecvmfs
+    #- name: Cache cvmfs cache
+    #  id: cvmfs_cache
+    #  uses: actions/cache@main
+    #  with:
+    #    path: /var/lib/cvmfs/shared
+    #    key: cachecvmfs
 
     - name: restore dir permission
       run: |

--- a/.github/workflows/test_daq_buildtools.yml
+++ b/.github/workflows/test_daq_buildtools.yml
@@ -16,31 +16,17 @@ on:
         description: "Branch from which to run test_daq-buildtools.sh"
 
 jobs:
-  load_cvmfs:
-    name: Load CVMFS
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        shell: bash
-
-    steps: 
-    - uses: cvmfs-contrib/github-action-cvmfs@v5
-      with:
-        cvmfs_repositories: 'dunedaq-development.opensciencegrid.org'
-
   test_daq_buildtools:
     name: Test daq-buildtools
-    needs: load_cvmfs
     runs-on: ubuntu-latest
-    container:
-      image: ghcr.io/dune-daq/nightly-release-alma9:development_v5
-      volumes: 
-        - /cvmfs:/cvmfs
     defaults:
       run:
         shell: bash
 
     steps:
+    - uses: cvmfs-contrib/github-action-cvmfs@v5
+      with:
+        cvmfs_repositories: 'dunedaq-development.opensciencegrid.org'
     - name: Check CVMFS
       run: |
         ls -lrt /cvmfs || exit 1
@@ -55,6 +41,11 @@ jobs:
         cd daq-buildtools-test
         source env.sh
         cd scripts
-        ./test_daq-buildtools.sh --dbt-branch ${{ github.head_ref }}
+        #./test_daq-buildtools.sh --dbt-branch ${{ github.head_ref }}
+        docker run --rm -it \
+          --mount type=bind,src=/cvmfs,dst=/cvmfs,bind-propagation=shared \
+          ghcr.io/dune-daq/nightly-release-alma9:development_v5 \
+          ./test_daq-buildtools.sh --dbt-branch ${{ github.head_ref }}
+
         
 

--- a/.github/workflows/test_daq_buildtools.yml
+++ b/.github/workflows/test_daq_buildtools.yml
@@ -27,26 +27,6 @@ jobs:
     - uses: cvmfs-contrib/github-action-cvmfs@v5
       with:
         cvmfs_repositories: 'dunedaq-development.opensciencegrid.org'
-    - name: Check CVMFS
-      run: |
-        ls -lrt /cvmfs || exit 1
-
-    - name: change dir permission
-      run: |
-        sudo mkdir -p /var/lib/cvmfs
-        sudo chmod -R 777 /var/lib/cvmfs
-  
-    #- name: Cache cvmfs cache
-    #  id: cvmfs_cache
-    #  uses: actions/cache@main
-    #  with:
-    #    path: /var/lib/cvmfs/shared
-    #    key: cachecvmfs
-
-    - name: restore dir permission
-      run: |
-        sudo chown -R cvmfs:cvmfs /var/lib/cvmfs
-        sudo chmod -R 700 /var/lib/cvmfs
 
     - name: Pull latest nightly build image
       run: docker pull ghcr.io/dune-daq/nightly-release-alma9:development_v5
@@ -63,7 +43,6 @@ jobs:
         cd daq-buildtools-test
         source env.sh
         cd scripts
-        #./test_daq-buildtools.sh --dbt-branch ${{ github.head_ref }}
         docker run --rm \
           -v /cvmfs:/cvmfs:shared \
           -v "$PWD":/workspace \

--- a/scripts/test_daq-buildtools.sh
+++ b/scripts/test_daq-buildtools.sh
@@ -102,6 +102,10 @@ git clone https://github.com/DUNE-DAQ/$pyrepo || exit 16
 cd ..
 . env.sh || exit 17
 rm -f .venv/lib64/python*/site-packages/$pyrepo/__init__.py || exit 18
+
+echo "******************************TEST dbt-build --lint *************************************"
+dbt-build --lint || exit 123
+
 echo "******************************TEST dbt-build (Python) *************************************"
 dbt-build || exit 19
 find .venv/lib64/python*/site-packages/$pyrepo/__init__.py | read || exit 20

--- a/scripts/test_daq-buildtools.sh
+++ b/scripts/test_daq-buildtools.sh
@@ -33,6 +33,13 @@ repo="ipm"
 pyrepo="daqpytools"
 dbt_branch="develop"
 
+validate_arg() {
+    if [[ -z "$2" || "$2" == -* ]]; then
+        echo "ERROR: $1 requires an argument."
+        exit 2
+    fi
+}
+
 while [[ $# -gt 0 ]]; do
     case "$1" in
     -h|--help|-?)
@@ -40,14 +47,17 @@ while [[ $# -gt 0 ]]; do
         exit 1
         ;;
     --release)
+        validate_arg $1 $2
         release="$2"
         shift 2
         ;;
     --repo)
+        validate_arg $1 $2
         repo="$2"
         shift 2
         ;;
     --dbt-branch)
+        validate_arg $1 $2
         dbt_branch="$2"
         shift 2
         ;;

--- a/scripts/test_daq-buildtools.sh
+++ b/scripts/test_daq-buildtools.sh
@@ -96,14 +96,14 @@ mkdir -p "$release_tmpdir" && cd "$release_tmpdir"
 
 echo "*********************************TEST dbt-setup-release *******************************"
 # Check that dbt-setup-release works without altering the environment, thus the (...)
-time (dbt-setup-release "${extra_args[@]}" "$release"; echo $? > $release_tmpdir/dbt-setup-release_result.txt)
+(dbt-setup-release "${extra_args[@]}" "$release"; echo $? > $release_tmpdir/dbt-setup-release_result.txt)
 
 test -e $release_tmpdir/dbt-setup-release_result.txt || exit 3
 test $( cat $release_tmpdir/dbt-setup-release_result.txt ) == 0 || exit 4
 rm -f dbt-setup-release_result.txt
 
 echo "*********************************TEST dbt-create ***************************************"
-time dbt-create -s ${extra_args[@]} $release || exit 5
+dbt-create -s ${extra_args[@]} $release || exit 5
 cd $(ls)  # Only thing in the directory will be the work area
 
 
@@ -114,7 +114,7 @@ cd ..
 rm -f .venv/lib64/python*/site-packages/$pyrepo/__init__.py || exit 18
 
 echo "******************************TEST dbt-build (Python) *************************************"
-time dbt-build || exit 19
+dbt-build || exit 19
 find .venv/lib64/python*/site-packages/$pyrepo/__init__.py | read || exit 20
 rm -rf pythoncode/$pyrepo
 
@@ -124,18 +124,18 @@ cd ..
 . env.sh || exit 7
 
 echo "******************************TEST dbt-build (C++) *************************************"
-time dbt-build || exit 8
+dbt-build || exit 8
 
 echo "******************************TEST dbt-build --unittest *********************************"
-time dbt-build --unittest || exit 9
+dbt-build --unittest || exit 9
 
 if spack find --loaded llvm >/dev/null 2>&1; then
     echo "******************************TEST dbt-build --lint *************************************"
-    time dbt-build --lint || exit 10
+    dbt-build --lint || exit 10
 
     echo "******************************TEST dbt-clang-format.sh *************************************"
     cd $DBT_AREA_ROOT/sourcecode
-    time dbt-clang-format.sh $repo --view-differences-only || exit 11
+    dbt-clang-format.sh $repo --view-differences-only || exit 11
     cd ..
 else
     echo "WARNING: Skipping dbt-build --lint and dbt-clang-format.sh since llvm is not loaded"
@@ -143,7 +143,7 @@ fi
 
 if spack find --loaded lcov >/dev/null 2>&1; then
     echo "*********************************TEST dbt-lcov.sh****************************************"
-    time dbt-lcov.sh || exit 12
+    dbt-lcov.sh || exit 12
 else
     echo "WARNING: Skipping dbt-lcov.sh since lcov is not loaded"
 fi
@@ -152,10 +152,10 @@ fi
 echo "***********************TEST dbt-build with external sourcecode **************************"
 mv sourcecode $release_tmpdir
 ln -s $release_tmpdir/sourcecode
-time dbt-build --clean || exit 13
+dbt-build --clean || exit 13
 
 echo "*****************************TEST dbt-build --codegen **********************************"
-time dbt-build --codegen || exit 14
+dbt-build --codegen || exit 14
 
 
 echo "********************TEST local workarea Spack package installation **********************"

--- a/scripts/test_daq-buildtools.sh
+++ b/scripts/test_daq-buildtools.sh
@@ -96,14 +96,14 @@ mkdir -p "$release_tmpdir" && cd "$release_tmpdir"
 
 echo "*********************************TEST dbt-setup-release *******************************"
 # Check that dbt-setup-release works without altering the environment, thus the (...)
-(dbt-setup-release "${extra_args[@]}" "$release"; echo $? > $release_tmpdir/dbt-setup-release_result.txt)
+time (dbt-setup-release "${extra_args[@]}" "$release"; echo $? > $release_tmpdir/dbt-setup-release_result.txt)
 
 test -e $release_tmpdir/dbt-setup-release_result.txt || exit 3
 test $( cat $release_tmpdir/dbt-setup-release_result.txt ) == 0 || exit 4
 rm -f dbt-setup-release_result.txt
 
 echo "*********************************TEST dbt-create ***************************************"
-dbt-create -s ${extra_args[@]} $release || exit 5
+time dbt-create -s ${extra_args[@]} $release || exit 5
 cd $(ls)  # Only thing in the directory will be the work area
 
 
@@ -113,11 +113,8 @@ cd ..
 . env.sh || exit 17
 rm -f .venv/lib64/python*/site-packages/$pyrepo/__init__.py || exit 18
 
-echo "******************************TEST dbt-build --lint *************************************"
-dbt-build --lint || exit 123
-
 echo "******************************TEST dbt-build (Python) *************************************"
-dbt-build || exit 19
+time dbt-build || exit 19
 find .venv/lib64/python*/site-packages/$pyrepo/__init__.py | read || exit 20
 rm -rf pythoncode/$pyrepo
 
@@ -127,18 +124,18 @@ cd ..
 . env.sh || exit 7
 
 echo "******************************TEST dbt-build (C++) *************************************"
-dbt-build || exit 8
+time dbt-build || exit 8
 
 echo "******************************TEST dbt-build --unittest *********************************"
-dbt-build --unittest || exit 9
+time dbt-build --unittest || exit 9
 
 if spack find --loaded llvm >/dev/null 2>&1; then
     echo "******************************TEST dbt-build --lint *************************************"
-    dbt-build --lint || exit 10
+    time dbt-build --lint || exit 10
 
     echo "******************************TEST dbt-clang-format.sh *************************************"
     cd $DBT_AREA_ROOT/sourcecode
-    dbt-clang-format.sh $repo --view-differences-only || exit 11
+    time dbt-clang-format.sh $repo --view-differences-only || exit 11
     cd ..
 else
     echo "WARNING: Skipping dbt-build --lint and dbt-clang-format.sh since llvm is not loaded"
@@ -146,7 +143,7 @@ fi
 
 if spack find --loaded lcov >/dev/null 2>&1; then
     echo "*********************************TEST dbt-lcov.sh****************************************"
-    dbt-lcov.sh || exit 12
+    time dbt-lcov.sh || exit 12
 else
     echo "WARNING: Skipping dbt-lcov.sh since lcov is not loaded"
 fi
@@ -155,10 +152,10 @@ fi
 echo "***********************TEST dbt-build with external sourcecode **************************"
 mv sourcecode $release_tmpdir
 ln -s $release_tmpdir/sourcecode
-dbt-build --clean || exit 13
+time dbt-build --clean || exit 13
 
 echo "*****************************TEST dbt-build --codegen **********************************"
-dbt-build --codegen || exit 14
+time dbt-build --codegen || exit 14
 
 
 echo "********************TEST local workarea Spack package installation **********************"


### PR DESCRIPTION
# Description

This PR allows the `test_daq_buildtools.yml` workflow to run linting and code coverage steps. This was previously not the case due to the need of `llvm` and `lcov`, which we resolve by bind mounting CVMFS into the nightly build container in which the test script runs. This same idea should also be applicable to single-package CI builds.

When working on this, I noticed that `test_daq-buildtools.sh` would hang indefinitely if given a malformed argument, such as `--dbt-branch ${{ github.head_ref }}` when `${{ github.head_ref }}` was invalid. I added a function to `test_daq-buildtools.sh` which ensures that any flags passed also have a corresponding argument. I also made the argument passed to `--dbt-branch` default to `${{ github.ref_name }}` to further avoid invalid arguments. 

An example test run is [here](https://github.com/DUNE-DAQ/daq-buildtools/actions/runs/23264890122). Note that for this run, I prepended `time` to each `dbt-*` command to see how long each took. It seems the initial loading of CVMFS is quite slow, since `dbt-setup-release` took over 10 minutes. I'm not sure of a good way around this. Also, the test workflow should trigger when I open this PR.

_Please also include instructions for how a reviewer can test your changes._


## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [x] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking change that improves code/performance)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Testing checklist

- [ ] Unit tests pass (e.g. `dbt-build --unittest`)
- [ ] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [ ] Full set of integration tests pass (`daqsystemtest_integtest_bundle.sh`)
- [ ] Python tests pass if applicable (e.g. `python -m pytest`)
- [ ] Pre-commit hooks run successfully if applicable (e.g. `pre-commit run --all-files`)

_Comments here on the testing_

## Further checks

- [ ] Code is commented where needed, particularly in hard-to-understand areas
- [ ] Code style is correct (`dbt-build --lint`, and/or see https://dune-daq-sw.readthedocs.io/en/latest/packages/styleguide/)
- [ ] If applicable, new tests have been added or an issue has been opened to tackle that in the future.
  (Indicate issue here: # (issue))

